### PR TITLE
컨벤션 관련 기능 추가.

### DIFF
--- a/Athena.Cache.Core/Attributes/NoConventionInvalidationAttribute.cs
+++ b/Athena.Cache.Core/Attributes/NoConventionInvalidationAttribute.cs
@@ -1,0 +1,11 @@
+﻿namespace Athena.Cache.Core.Attributes;
+
+/// <summary>
+/// Convention 기반 테이블명 추론을 비활성화하는 Attribute
+/// 이 어트리뷰트가 적용된 컨트롤러/액션은 명시적으로 선언된 CacheInvalidateOn만 사용하고,
+/// Convention 기반 자동 추론은 수행하지 않습니다.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public class NoConventionInvalidationAttribute : Attribute
+{
+}

--- a/Athena.Cache.Core/Configuration/ConventionOptions.cs
+++ b/Athena.Cache.Core/Configuration/ConventionOptions.cs
@@ -14,6 +14,15 @@ public class ConventionOptions
     /// <summary>Humanizer 라이브러리 사용</summary>
     public bool UseHumanizer { get; set; } = false;
 
-    /// <summary>커스텀 복수형 변환 함수</summary>
+    /// <summary>커스텀 복수형 변환 함수 (단일 테이블)</summary>
     public Func<string, string>? CustomPluralizer { get; set; }
+
+    /// <summary>커스텀 다중 테이블 추론 함수</summary>
+    public Func<string, string[]>? CustomMultiTableInferrer { get; set; }
+
+    /// <summary>컨트롤러별 테이블 매핑 사전 (컨트롤러명 → 테이블명 배열)</summary>
+    public Dictionary<string, string[]> ControllerTableMappings { get; set; } = new();
+
+    /// <summary>Convention 기반 추론에서 제외할 컨트롤러명 목록</summary>
+    public HashSet<string> ExcludedControllers { get; set; } = new();
 }

--- a/Athena.Cache.Core/Filters/AthenaCacheActionFilter.cs
+++ b/Athena.Cache.Core/Filters/AthenaCacheActionFilter.cs
@@ -42,23 +42,57 @@ public class AthenaCacheActionFilter(ILogger<AthenaCacheActionFilter> logger) : 
             // 액션 실행
             var executedContext = await next();
 
-            // 액션 실행 후 테이블 추적 설정
+            // 액션 실행 후 HTTP 메서드별 처리
             if (executedContext.HttpContext.Items.TryGetValue("AthenaCache.Config", out var configObj) &&
                 configObj is CacheConfiguration config &&
                 config.InvalidationRules.Any())
             {
                 var invalidator = executedContext.HttpContext.RequestServices.GetService<ICacheInvalidator>();
-                var cacheKey = executedContext.HttpContext.Items["AthenaCache.GeneratedKey"] as string;
-
-                if (invalidator != null && !string.IsNullOrEmpty(cacheKey))
+                if (invalidator != null)
                 {
-                    // 캐시 키를 테이블들과 연결하여 추적
-                    var tablesToTrack = config.InvalidationRules
-                        .Select(rule => rule.TableName)
-                        .Distinct()
-                        .ToArray();
+                    var httpMethod = executedContext.HttpContext.Request.Method;
+                    
+                    if (IsGetRequest(httpMethod))
+                    {
+                        // GET 요청: 캐시 키를 테이블들과 연결하여 추적
+                        var cacheKey = executedContext.HttpContext.Items["AthenaCache.GeneratedKey"] as string;
+                        if (!string.IsNullOrEmpty(cacheKey))
+                        {
+                            var tablesToTrack = config.InvalidationRules
+                                .Select(rule => rule.TableName)
+                                .Distinct()
+                                .ToArray();
 
-                    await invalidator.TrackCacheKeyAsync(tablesToTrack, cacheKey);
+                            await invalidator.TrackCacheKeyAsync(tablesToTrack, cacheKey);
+                            
+                            if (context.HttpContext.RequestServices.GetService<AthenaCacheOptions>() is AthenaCacheOptions options &&
+                                options.Logging.LogInvalidation)
+                            {
+                                logger.LogDebug("Tracked cache key for tables [{Tables}] in {Controller}.{Action}",
+                                    string.Join(", ", tablesToTrack), config.Controller, config.Action);
+                            }
+                        }
+                    }
+                    else if (IsModifyingRequest(httpMethod))
+                    {
+                        // POST/PUT/DELETE 요청: 관련 테이블 캐시 무효화
+                        var tablesToInvalidate = config.InvalidationRules
+                            .Select(rule => rule.TableName)
+                            .Distinct()
+                            .ToArray();
+
+                        foreach (var tableName in tablesToInvalidate)
+                        {
+                            await invalidator.InvalidateAsync(tableName);
+                        }
+                        
+                        if (context.HttpContext.RequestServices.GetService<AthenaCacheOptions>() is AthenaCacheOptions options &&
+                            options.Logging.LogInvalidation)
+                        {
+                            logger.LogInformation("Invalidated cache for tables [{Tables}] after {Method} {Controller}.{Action}",
+                                string.Join(", ", tablesToInvalidate), httpMethod, config.Controller, config.Action);
+                        }
+                    }
                 }
             }
         }
@@ -76,6 +110,25 @@ public class AthenaCacheActionFilter(ILogger<AthenaCacheActionFilter> logger) : 
             .Any(fd => fd.Filter is NoCacheAttribute);
     }
 
+    /// <summary>
+    /// GET 요청인지 확인
+    /// </summary>
+    private static bool IsGetRequest(string httpMethod)
+    {
+        return string.Equals(httpMethod, "GET", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// 데이터 수정 요청인지 확인 (POST, PUT, DELETE, PATCH)
+    /// </summary>
+    private static bool IsModifyingRequest(string httpMethod)
+    {
+        return string.Equals(httpMethod, "POST", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(httpMethod, "PUT", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(httpMethod, "DELETE", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(httpMethod, "PATCH", StringComparison.OrdinalIgnoreCase);
+    }
+
     private static CacheConfiguration? BuildCacheConfiguration(ActionExecutingContext context)
     {
         var controllerName = context.Controller.GetType().Name;
@@ -88,8 +141,11 @@ public class AthenaCacheActionFilter(ILogger<AthenaCacheActionFilter> logger) : 
             return null;
         }
 
-        // CacheInvalidateOnAttribute들 수집
+        // CacheInvalidateOnAttribute들 수집 (명시적 선언)
         var invalidationAttributes = GetAttributes<CacheInvalidateOnAttribute>(context);
+
+        // Convention 기반 테이블명 추론 및 병합
+        var allInvalidationRules = MergeInvalidationRules(context, invalidationAttributes, controllerName);
 
         var config = new CacheConfiguration
         {
@@ -101,14 +157,7 @@ public class AthenaCacheActionFilter(ILogger<AthenaCacheActionFilter> logger) : 
             AdditionalKeyParameters = cacheAttribute?.AdditionalKeyParameters ?? [],
             ExcludeParameters = cacheAttribute?.ExcludeParameters ?? [],
             CustomKeyPrefix = cacheAttribute?.CustomKeyPrefix,
-            InvalidationRules = invalidationAttributes.Select(attr => new TableInvalidationRule
-            {
-                TableName = attr.TableName,
-                InvalidationType = attr.InvalidationType,
-                Pattern = attr.Pattern,
-                RelatedTables = attr.RelatedTables,
-                MaxDepth = attr.MaxDepth
-            }).ToList()
+            InvalidationRules = allInvalidationRules
         };
 
         return config;
@@ -154,5 +203,150 @@ public class AthenaCacheActionFilter(ILogger<AthenaCacheActionFilter> logger) : 
         attributes.AddRange(controllerAttributes);
 
         return attributes;
+    }
+
+    /// <summary>
+    /// Convention 기반 테이블명 추론과 명시적 선언을 병합
+    /// </summary>
+    private static List<TableInvalidationRule> MergeInvalidationRules(
+        ActionExecutingContext context, 
+        IEnumerable<CacheInvalidateOnAttribute> explicitAttributes, 
+        string controllerName)
+    {
+        var rules = new List<TableInvalidationRule>();
+
+        // 1. 명시적 선언 추가 (최우선)
+        rules.AddRange(explicitAttributes.Select(attr => new TableInvalidationRule
+        {
+            TableName = attr.TableName,
+            InvalidationType = attr.InvalidationType,
+            Pattern = attr.Pattern,
+            RelatedTables = attr.RelatedTables,
+            MaxDepth = attr.MaxDepth
+        }));
+
+        // 2. Convention 기반 추론 추가
+        var conventionOptions = context.HttpContext.RequestServices.GetService<AthenaCacheOptions>()?.Convention;
+        if (conventionOptions?.Enabled == true && !IsConventionDisabled(context, controllerName, conventionOptions))
+        {
+            var inferredTableNames = InferTableNamesFromController(controllerName, conventionOptions);
+            
+            foreach (var tableName in inferredTableNames)
+            {
+                // 이미 명시적으로 선언된 테이블은 중복 추가하지 않음
+                if (!rules.Any(r => r.TableName.Equals(tableName, StringComparison.OrdinalIgnoreCase)))
+                {
+                    rules.Add(new TableInvalidationRule
+                    {
+                        TableName = tableName,
+                        InvalidationType = InvalidationType.All,
+                        Pattern = null,
+                        RelatedTables = [],
+                        MaxDepth = -1
+                    });
+                }
+            }
+        }
+
+        return rules;
+    }
+
+    /// <summary>
+    /// 컨트롤러명에서 테이블명 추론
+    /// </summary>
+    private static string[] InferTableNamesFromController(string controllerName, ConventionOptions conventionOptions)
+    {
+        // 1. 설정 기반 매핑 확인 (최우선)
+        if (conventionOptions.ControllerTableMappings.TryGetValue(controllerName, out var mappedTables))
+        {
+            return mappedTables;
+        }
+
+        // 2. 커스텀 다중 테이블 추론 함수 사용
+        if (conventionOptions.CustomMultiTableInferrer != null)
+        {
+            return conventionOptions.CustomMultiTableInferrer(controllerName);
+        }
+
+        // 3. 기본 단일 테이블 추론
+        var baseTableName = ExtractBaseTableName(controllerName, conventionOptions);
+        return [baseTableName];
+    }
+
+    /// <summary>
+    /// 컨트롤러명에서 기본 테이블명 추출
+    /// </summary>
+    private static string ExtractBaseTableName(string controllerName, ConventionOptions conventionOptions)
+    {
+        // "Controller" 접미사 제거
+        var baseName = controllerName.EndsWith("Controller", StringComparison.OrdinalIgnoreCase)
+            ? controllerName[..^10]  // "Controller" 길이 = 10
+            : controllerName;
+
+        // 커스텀 단일 변환 함수 사용
+        if (conventionOptions.CustomPluralizer != null)
+        {
+            return conventionOptions.CustomPluralizer(baseName);
+        }
+
+        // 기본 동작: 복수형 변환 여부에 따라 처리
+        if (conventionOptions.UsePluralizer)
+        {
+            // 간단한 복수형 변환 (향후 Humanizer 라이브러리 연동 가능)
+            return ConvertToPlural(baseName);
+        }
+
+        return baseName;
+    }
+
+    /// <summary>
+    /// 간단한 복수형 변환 (기본 구현)
+    /// </summary>
+    private static string ConvertToPlural(string singular)
+    {
+        // 이미 복수형인지 확인 (간단한 휴리스틱)
+        if (singular.EndsWith("s", StringComparison.OrdinalIgnoreCase) ||
+            singular.EndsWith("es", StringComparison.OrdinalIgnoreCase))
+        {
+            return singular;
+        }
+
+        // 기본 복수형 규칙
+        if (singular.EndsWith("y", StringComparison.OrdinalIgnoreCase))
+        {
+            return singular[..^1] + "ies";
+        }
+        
+        if (singular.EndsWith("s", StringComparison.OrdinalIgnoreCase) ||
+            singular.EndsWith("sh", StringComparison.OrdinalIgnoreCase) ||
+            singular.EndsWith("ch", StringComparison.OrdinalIgnoreCase) ||
+            singular.EndsWith("x", StringComparison.OrdinalIgnoreCase) ||
+            singular.EndsWith("z", StringComparison.OrdinalIgnoreCase))
+        {
+            return singular + "es";
+        }
+
+        return singular + "s";
+    }
+
+    /// <summary>
+    /// Convention 기반 추론이 비활성화되어 있는지 확인
+    /// </summary>
+    private static bool IsConventionDisabled(ActionExecutingContext context, string controllerName, ConventionOptions conventionOptions)
+    {
+        // 1. NoConventionInvalidationAttribute 체크 (액션 레벨 우선)
+        var noConventionAttribute = GetAttribute<NoConventionInvalidationAttribute>(context);
+        if (noConventionAttribute != null)
+        {
+            return true;
+        }
+
+        // 2. 전역 설정에서 제외된 컨트롤러 체크
+        if (conventionOptions.ExcludedControllers.Contains(controllerName))
+        {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/Athena.Cache.Sample/Controllers/OrdersController.cs
+++ b/Athena.Cache.Sample/Controllers/OrdersController.cs
@@ -12,11 +12,10 @@ public class OrdersController(IOrderService orderService, ILogger<OrdersControll
     : ControllerBase
 {
     /// <summary>
-    /// 주문 목록 조회 (Orders, Users 테이블과 연관)
+    /// 주문 목록 조회 (Convention 기반 Orders + 명시적 Users 테이블과 연관)
     /// </summary>
     [HttpGet]
     [AthenaCache(ExpirationMinutes = 20)]
-    [CacheInvalidateOn("Orders")]
     [CacheInvalidateOn("Users", InvalidationType.Related, "Orders")]
     public async Task<ActionResult<IEnumerable<OrderDto>>> GetOrders(
         [FromQuery] int? userId = null,
@@ -30,11 +29,10 @@ public class OrdersController(IOrderService orderService, ILogger<OrdersControll
     }
 
     /// <summary>
-    /// 특정 주문 조회
+    /// 특정 주문 조회 (Convention 기반 Orders + 명시적 Users 테이블 변경 시 무효화)
     /// </summary>
     [HttpGet("{id}")]
     [AthenaCache(ExpirationMinutes = 45)]
-    [CacheInvalidateOn("Orders")]
     [CacheInvalidateOn("Users")]
     public async Task<ActionResult<OrderDto>> GetOrder(int id)
     {
@@ -48,9 +46,10 @@ public class OrdersController(IOrderService orderService, ILogger<OrdersControll
     }
 
     /// <summary>
-    /// 주문 생성
+    /// 주문 생성 (Convention 기반 Orders + 명시적 Users 테이블 무효화)
     /// </summary>
     [HttpPost]
+    [CacheInvalidateOn("Users", InvalidationType.Related, "Orders")]
     public async Task<ActionResult<OrderDto>> CreateOrder([FromBody] Order order)
     {
         if (!ModelState.IsValid)
@@ -63,9 +62,10 @@ public class OrdersController(IOrderService orderService, ILogger<OrdersControll
     }
 
     /// <summary>
-    /// 주문 삭제
+    /// 주문 삭제 (Convention 기반 Orders + 명시적 Users 테이블 무효화)
     /// </summary>
     [HttpDelete("{id}")]
+    [CacheInvalidateOn("Users", InvalidationType.Related, "Orders")]
     public async Task<ActionResult> DeleteOrder(int id)
     {
         var deleted = await orderService.DeleteOrderAsync(id);

--- a/Athena.Cache.Sample/Controllers/ReportsController.cs
+++ b/Athena.Cache.Sample/Controllers/ReportsController.cs
@@ -1,0 +1,121 @@
+using Athena.Cache.Core.Abstractions;
+using Athena.Cache.Core.Attributes;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Athena.Cache.Sample.Controllers;
+
+/// <summary>
+/// Convention 기반 추론을 비활성화한 컨트롤러 예제
+/// 캐싱은 사용하지만, 무효화는 수동으로 제어
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+[NoConventionInvalidation]  // Convention 기반 추론 비활성화
+public class ReportsController(ICacheInvalidator cacheInvalidator, ILogger<ReportsController> logger) : ControllerBase
+{
+    /// <summary>
+    /// 보고서 데이터 조회 (캐싱만, 자동 무효화 없음)
+    /// </summary>
+    [HttpGet("monthly")]
+    [AthenaCache(ExpirationMinutes = 120)]
+    public async Task<ActionResult<object>> GetMonthlyReport([FromQuery] int year = 2024, [FromQuery] int month = 1)
+    {
+        logger.LogInformation("GetMonthlyReport called with year: {Year}, month: {Month}", year, month);
+
+        // 실제로는 데이터베이스에서 복잡한 집계 쿼리 실행
+        await Task.Delay(100); // 시뮬레이션
+        
+        var report = new
+        {
+            Year = year,
+            Month = month,
+            TotalUsers = 1500,
+            TotalOrders = 3200,
+            Revenue = 125000.50m,
+            GeneratedAt = DateTime.UtcNow
+        };
+
+        return Ok(report);
+    }
+
+    /// <summary>
+    /// 연간 보고서 조회 (명시적으로 특정 테이블만 무효화)
+    /// </summary>
+    [HttpGet("yearly")]
+    [AthenaCache(ExpirationMinutes = 240)]
+    [CacheInvalidateOn("UserStatistics")]  // Convention 없이 명시적으로만
+    [CacheInvalidateOn("OrderStatistics")]
+    public async Task<ActionResult<object>> GetYearlyReport([FromQuery] int year = 2024)
+    {
+        logger.LogInformation("GetYearlyReport called with year: {Year}", year);
+
+        await Task.Delay(200); // 시뮬레이션
+        
+        var report = new
+        {
+            Year = year,
+            TotalUsers = 18000,
+            TotalOrders = 45000,
+            Revenue = 1850000.75m,
+            GeneratedAt = DateTime.UtcNow
+        };
+
+        return Ok(report);
+    }
+
+    /// <summary>
+    /// 보고서 데이터 새로 고침 (수동 캐시 무효화)
+    /// </summary>
+    [HttpPost("refresh")]
+    public async Task<ActionResult> RefreshReportData([FromQuery] string? reportType = null)
+    {
+        logger.LogInformation("RefreshReportData called with reportType: {ReportType}", reportType);
+
+        // 수동으로 캐시 무효화
+        switch (reportType?.ToLower())
+        {
+            case "monthly":
+                await cacheInvalidator.InvalidateByPatternAsync("*GetMonthlyReport*");
+                logger.LogInformation("Monthly report cache invalidated");
+                break;
+                
+            case "yearly":
+                await cacheInvalidator.InvalidateByPatternAsync("*GetYearlyReport*");
+                logger.LogInformation("Yearly report cache invalidated");
+                break;
+                
+            case null:
+            case "all":
+                await cacheInvalidator.InvalidateByPatternAsync("*Report*");
+                logger.LogInformation("All report caches invalidated");
+                break;
+                
+            default:
+                return BadRequest($"Unknown report type: {reportType}");
+        }
+
+        return Ok(new { Message = "Report cache refreshed successfully", ReportType = reportType ?? "all" });
+    }
+
+    /// <summary>
+    /// 캐시 없이 실시간 데이터 조회
+    /// </summary>
+    [HttpGet("realtime")]
+    [NoCache]
+    public async Task<ActionResult<object>> GetRealtimeData()
+    {
+        logger.LogInformation("GetRealtimeData called - 캐시 없이 실시간 데이터");
+
+        await Task.Delay(50); // 시뮬레이션
+        
+        var data = new
+        {
+            CurrentActiveUsers = Random.Shared.Next(100, 500),
+            PendingOrders = Random.Shared.Next(10, 50),
+            ServerLoad = Random.Shared.NextDouble() * 100,
+            Timestamp = DateTime.UtcNow
+        };
+
+        return Ok(data);
+    }
+}


### PR DESCRIPTION
  구현 완료 요약

  ✅ NoConventionInvalidation 기능 구현

  1. NoConventionInvalidationAttribute

  - 컨트롤러/액션 레벨에서 Convention 추론 비활성화
  - 명시적 CacheInvalidateOn은 여전히 작동

  2. ConventionOptions 확장

  - ExcludedControllers: 전역 설정으로 특정 컨트롤러들 제외 가능

  3. AthenaCacheActionFilter 개선

  - IsConventionDisabled: Convention 비활성화 여부 체크
  - 우선순위: 어트리뷰트 > 전역 제외 설정

  4. ReportsController 샘플

  - 실제 사용 예제: 캐싱만 하고 수동으로 무효화 제어
  - ICacheInvalidator를 통한 수동 캐시 관리 패턴