### PR TITLE
Release 1.1.7

### DIFF
--- a/Athena.Cache.Analytics/Models/CacheStatistics.cs
+++ b/Athena.Cache.Analytics/Models/CacheStatistics.cs
@@ -1,19 +1,35 @@
-﻿namespace Athena.Cache.Analytics.Models;
+﻿using Athena.Cache.Core.Abstractions;
+
+namespace Athena.Cache.Analytics.Models;
 
 /// <summary>
-/// 캐시 통계 집계
+/// 캐시 통계 집계 - ICacheMetrics 구현 (분석용)
 /// </summary>
-public class CacheStatistics
+public class CacheStatistics : ICacheMetrics
 {
+    // 분석 기간
     public DateTime PeriodStart { get; set; }
     public DateTime PeriodEnd { get; set; }
+    
+    // ICacheMetrics 인터페이스 구현
+    public DateTime Timestamp => PeriodEnd;
     public long TotalRequests { get; set; }
     public long TotalHits { get; set; }
     public long TotalMisses { get; set; }
     public double HitRatio { get; set; }
     public double AverageResponseTimeMs { get; set; }
+    public long MemoryUsageBytes => TotalCacheSize;
+    public long ItemCount => ActiveKeys;
+    public long TotalErrors { get; set; }
+    public long HotKeysCount { get; set; }
+    public long TotalInvalidations { get; set; }
+    
+    // Analytics 고유 속성
     public long TotalCacheSize { get; set; }
     public int ActiveKeys { get; set; }
     public Dictionary<string, long> EndpointHits { get; set; } = new();
     public Dictionary<string, long> TableInvalidations { get; set; } = new();
+    
+    // 분석 기간 정보
+    public TimeSpan AnalysisPeriod => PeriodEnd - PeriodStart;
 }

--- a/Athena.Cache.Core/Abstractions/CacheStatistics.cs
+++ b/Athena.Cache.Core/Abstractions/CacheStatistics.cs
@@ -12,4 +12,6 @@ public class CacheStatistics
     public long TotalRequests => HitCount + MissCount;
     public TimeSpan Uptime { get; set; }
     public long MemoryUsage { get; set; } // bytes
+    public long ItemCount { get; set; }
+    public DateTime LastCleanup { get; set; }
 }

--- a/Athena.Cache.Core/Abstractions/ICacheInvalidator.cs
+++ b/Athena.Cache.Core/Abstractions/ICacheInvalidator.cs
@@ -34,4 +34,14 @@ public interface ICacheInvalidator
     /// 관련 테이블들과 함께 연쇄 무효화
     /// </summary>
     Task InvalidateWithRelatedAsync(string tableName, string[] relatedTables, int maxDepth = 3, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 여러 테이블을 배치로 무효화 (성능 최적화)
+    /// </summary>
+    Task InvalidateBatchAsync(IEnumerable<string> tableNames, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 여러 패턴을 배치로 무효화 (성능 최적화)
+    /// </summary>
+    Task InvalidateByPatternBatchAsync(IEnumerable<string> patterns, CancellationToken cancellationToken = default);
 }

--- a/Athena.Cache.Core/Abstractions/ICacheKeyGenerator.cs
+++ b/Athena.Cache.Core/Abstractions/ICacheKeyGenerator.cs
@@ -6,9 +6,14 @@
 public interface ICacheKeyGenerator
 {
     /// <summary>
-    /// API 요청 파라미터를 기반으로 캐시 키 생성
+    /// API 요청 파라미터를 기반으로 캐시 키 생성 (동기)
     /// </summary>
     string GenerateKey(string controller, string action, IDictionary<string, object?>? parameters = null);
+
+    /// <summary>
+    /// API 요청 파라미터를 기반으로 캐시 키 생성 (비동기 최적화)
+    /// </summary>
+    ValueTask<string> GenerateKeyAsync(string controller, string action, IDictionary<string, object?>? parameters = null);
 
     /// <summary>
     /// 테이블 추적용 키 생성

--- a/Athena.Cache.Core/Abstractions/ICacheMetrics.cs
+++ b/Athena.Cache.Core/Abstractions/ICacheMetrics.cs
@@ -1,0 +1,66 @@
+namespace Athena.Cache.Core.Abstractions;
+
+/// <summary>
+/// 캐시 메트릭 공통 인터페이스
+/// Core와 Monitoring 라이브러리 간 표준화된 메트릭 교환을 위한 계약
+/// </summary>
+public interface ICacheMetrics
+{
+    /// <summary>메트릭 수집 시점</summary>
+    DateTime Timestamp { get; }
+    
+    /// <summary>캐시 히트율 (0.0 ~ 1.0)</summary>
+    double HitRatio { get; }
+    
+    /// <summary>총 히트 수</summary>
+    long TotalHits { get; }
+    
+    /// <summary>총 미스 수</summary>
+    long TotalMisses { get; }
+    
+    /// <summary>총 요청 수</summary>
+    long TotalRequests => TotalHits + TotalMisses;
+    
+    /// <summary>메모리 사용량 (바이트)</summary>
+    long MemoryUsageBytes { get; }
+    
+    /// <summary>메모리 사용량 (MB)</summary>
+    double MemoryUsageMB => MemoryUsageBytes / (1024.0 * 1024.0);
+    
+    /// <summary>캐시 아이템 수</summary>
+    long ItemCount { get; }
+    
+    /// <summary>평균 응답 시간 (밀리초)</summary>
+    double AverageResponseTimeMs { get; }
+    
+    /// <summary>총 에러 수</summary>
+    long TotalErrors { get; }
+    
+    /// <summary>에러율 (0.0 ~ 1.0)</summary>
+    double ErrorRate => TotalRequests > 0 ? (double)TotalErrors / TotalRequests : 0.0;
+    
+    /// <summary>핫키 수</summary>
+    long HotKeysCount { get; }
+    
+    /// <summary>무효화 수</summary>
+    long TotalInvalidations { get; }
+}
+
+/// <summary>
+/// 확장 가능한 캐시 메트릭 인터페이스
+/// Monitoring 라이브러리에서 추가 메트릭을 위해 사용
+/// </summary>
+public interface IExtendedCacheMetrics : ICacheMetrics
+{
+    /// <summary>활성 연결 수</summary>
+    int ConnectionCount { get; }
+    
+    /// <summary>사용자 정의 메트릭</summary>
+    IReadOnlyDictionary<string, object> CustomMetrics { get; }
+    
+    /// <summary>분산 무효화 메시지 수</summary>
+    long DistributedInvalidationMessages { get; }
+    
+    /// <summary>Circuit Breaker 상태</summary>
+    string CircuitBreakerState { get; }
+}

--- a/Athena.Cache.Core/Abstractions/IDistributedCacheInvalidator.cs
+++ b/Athena.Cache.Core/Abstractions/IDistributedCacheInvalidator.cs
@@ -1,0 +1,88 @@
+namespace Athena.Cache.Core.Abstractions;
+
+/// <summary>
+/// 분산 환경에서 캐시 무효화를 위한 인터페이스
+/// Redis Pub/Sub 등을 통해 다중 인스턴스 간 캐시 동기화 제공
+/// </summary>
+public interface IDistributedCacheInvalidator : ICacheInvalidator
+{
+    /// <summary>
+    /// 분산 무효화 이벤트 수신 시작
+    /// </summary>
+    Task StartListeningAsync(CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// 분산 무효화 이벤트 수신 중지
+    /// </summary>
+    Task StopListeningAsync(CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// 분산 환경의 모든 인스턴스에 무효화 메시지 브로드캐스트
+    /// </summary>
+    Task BroadcastInvalidationAsync(string tableName, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// 패턴 기반 분산 무효화 브로드캐스트
+    /// </summary>
+    Task BroadcastInvalidationByPatternAsync(string pattern, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// 배치 분산 무효화 브로드캐스트
+    /// </summary>
+    Task BroadcastBatchInvalidationAsync(IEnumerable<string> tableNames, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// 현재 인스턴스 ID (분산 환경에서 구분용)
+    /// </summary>
+    string InstanceId { get; }
+    
+    /// <summary>
+    /// 분산 무효화 연결 상태
+    /// </summary>
+    bool IsConnected { get; }
+    
+    /// <summary>
+    /// 무효화 이벤트 발생 시 호출되는 이벤트
+    /// </summary>
+    event EventHandler<InvalidationEventArgs> InvalidationReceived;
+}
+
+/// <summary>
+/// 무효화 이벤트 인자
+/// </summary>
+public class InvalidationEventArgs : EventArgs
+{
+    public required string SourceInstanceId { get; init; }
+    public required InvalidationMessage Message { get; init; }
+    public DateTime Timestamp { get; init; } = DateTime.UtcNow;
+}
+
+/// <summary>
+/// 분산 무효화 메시지
+/// </summary>
+public class InvalidationMessage
+{
+    public required InvalidationType Type { get; init; }
+    public required string[] TableNames { get; init; }
+    public string? Pattern { get; init; }
+    public DateTime Timestamp { get; init; } = DateTime.UtcNow;
+    public string? CorrelationId { get; init; }
+}
+
+/// <summary>
+/// 무효화 타입
+/// </summary>
+public enum InvalidationType
+{
+    /// <summary>테이블 기반 무효화</summary>
+    Table,
+    
+    /// <summary>패턴 기반 무효화</summary>
+    Pattern,
+    
+    /// <summary>배치 무효화</summary>
+    Batch,
+    
+    /// <summary>전체 무효화</summary>
+    All
+}

--- a/Athena.Cache.Core/Abstractions/IDistributedCacheInvalidator.cs
+++ b/Athena.Cache.Core/Abstractions/IDistributedCacheInvalidator.cs
@@ -1,3 +1,5 @@
+using Athena.Cache.Core.Enums;
+
 namespace Athena.Cache.Core.Abstractions;
 
 /// <summary>
@@ -67,22 +69,4 @@ public class InvalidationMessage
     public string? Pattern { get; init; }
     public DateTime Timestamp { get; init; } = DateTime.UtcNow;
     public string? CorrelationId { get; init; }
-}
-
-/// <summary>
-/// 무효화 타입
-/// </summary>
-public enum InvalidationType
-{
-    /// <summary>테이블 기반 무효화</summary>
-    Table,
-    
-    /// <summary>패턴 기반 무효화</summary>
-    Pattern,
-    
-    /// <summary>배치 무효화</summary>
-    Batch,
-    
-    /// <summary>전체 무효화</summary>
-    All
 }

--- a/Athena.Cache.Core/Abstractions/IIntelligentCacheManager.cs
+++ b/Athena.Cache.Core/Abstractions/IIntelligentCacheManager.cs
@@ -1,0 +1,104 @@
+namespace Athena.Cache.Core.Abstractions;
+
+/// <summary>
+/// 지능형 캐시 관리 기능을 제공하는 인터페이스
+/// Hot Key Detection, Adaptive TTL, Cache Warming 등 고급 캐싱 패턴 지원
+/// </summary>
+public interface IIntelligentCacheManager
+{
+    /// <summary>
+    /// Hot Key 감지 시작
+    /// </summary>
+    Task StartHotKeyDetectionAsync(CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Hot Key 감지 중지
+    /// </summary>
+    Task StopHotKeyDetectionAsync();
+    
+    /// <summary>
+    /// 현재 Hot Key 목록 조회
+    /// </summary>
+    Task<IEnumerable<HotKeyInfo>> GetHotKeysAsync(int topCount = 10, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// 키의 사용 패턴을 기반으로 최적 TTL 계산
+    /// </summary>
+    Task<TimeSpan> CalculateAdaptiveTtlAsync(string cacheKey, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// 캐시 워밍 실행 (미리 데이터 로드)
+    /// </summary>
+    Task WarmCacheAsync(IEnumerable<string> keys, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// 캐시 사용 통계 기록
+    /// </summary>
+    Task RecordCacheAccessAsync(string cacheKey, CacheAccessType accessType, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// LRU/LFU 정책에 따른 캐시 정리
+    /// </summary>
+    Task EvictCacheByPolicyAsync(CacheEvictionPolicy policy, int maxItems, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// 키의 우선순위 계산 (사용 빈도, 최근 사용 등 고려)
+    /// </summary>
+    Task<double> CalculateKeyPriorityAsync(string cacheKey, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Hot Key 정보
+/// </summary>
+public class HotKeyInfo
+{
+    public required string Key { get; init; }
+    public long AccessCount { get; init; }
+    public double AccessRate { get; init; } // 접근/시간 비율
+    public DateTime FirstAccess { get; init; }
+    public DateTime LastAccess { get; init; }
+    public TimeSpan AverageInterval { get; init; }
+    public double Priority { get; init; }
+}
+
+/// <summary>
+/// 캐시 접근 타입
+/// </summary>
+public enum CacheAccessType
+{
+    /// <summary>캐시 히트</summary>
+    Hit,
+    
+    /// <summary>캐시 미스</summary>
+    Miss,
+    
+    /// <summary>캐시 설정</summary>
+    Set,
+    
+    /// <summary>캐시 삭제</summary>
+    Delete,
+    
+    /// <summary>캐시 만료</summary>
+    Expire
+}
+
+/// <summary>
+/// 캐시 교체 정책
+/// </summary>
+public enum CacheEvictionPolicy
+{
+    /// <summary>Least Recently Used - 가장 오래 사용되지 않은 항목 제거</summary>
+    LRU,
+    
+    /// <summary>Least Frequently Used - 가장 적게 사용된 항목 제거</summary>
+    LFU,
+    
+    /// <summary>Time To Live - 만료 시간 기준 제거</summary>
+    TTL,
+    
+    /// <summary>Random - 무작위 제거</summary>
+    Random,
+    
+    /// <summary>FIFO - First In First Out</summary>
+    FIFO
+}

--- a/Athena.Cache.Core/Analytics/CacheOptimizationAnalyzer.cs
+++ b/Athena.Cache.Core/Analytics/CacheOptimizationAnalyzer.cs
@@ -1,6 +1,5 @@
 using Athena.Cache.Core.Abstractions;
 using Athena.Cache.Core.Observability;
-using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
 
 namespace Athena.Cache.Core.Analytics;
@@ -89,13 +88,13 @@ public class CacheOptimizationAnalyzer : IDisposable
                 Title = "Low Cache Hit Rate Detected",
                 Description = $"Current hit rate is {snapshot.HitRatio:P1}, which is below optimal threshold of 70%",
                 Impact = EstimateHitRateImpact(snapshot.HitRatio),
-                Suggestions = new[]
-                {
+                Suggestions =
+                [
                     "Consider increasing cache TTL for frequently accessed data",
                     "Review cache key patterns for better cache locality",
                     "Implement cache warming for predictable access patterns",
                     "Analyze and optimize cache eviction policies"
-                },
+                ],
                 Metrics = new Dictionary<string, object>
                 {
                     { "current_hit_rate", snapshot.HitRatio },
@@ -120,13 +119,13 @@ public class CacheOptimizationAnalyzer : IDisposable
                     Title = "Significant Hit Rate Degradation",
                     Description = $"Hit rate dropped from {historicalAvg:P1} to {recentAvg:P1}",
                     Impact = $"Estimated {(historicalAvg - recentAvg) * 100:F0}% performance impact",
-                    Suggestions = new[]
-                    {
+                    Suggestions =
+                    [
                         "Investigate recent changes in data access patterns",
                         "Check for memory pressure causing premature evictions",
                         "Review recent application deployments or configuration changes",
                         "Consider emergency cache warming to restore performance"
-                    }
+                    ]
                 });
             }
         }
@@ -151,13 +150,13 @@ public class CacheOptimizationAnalyzer : IDisposable
                 Title = "High Memory Usage",
                 Description = $"Cache is using {memoryMB:F0}MB of memory",
                 Impact = "High memory usage may impact system performance",
-                Suggestions = new[]
-                {
+                Suggestions =
+                [
                     "Implement more aggressive cache eviction policies",
                     "Reduce TTL for less critical cached data",
                     "Consider compressing cached values",
                     "Review cache size limits and adjust accordingly"
-                },
+                ],
                 Metrics = new Dictionary<string, object>
                 {
                     { "memory_usage_mb", memoryMB },
@@ -179,13 +178,13 @@ public class CacheOptimizationAnalyzer : IDisposable
                     Title = "Memory Usage Increasing Trend",
                     Description = "Memory usage is consistently increasing",
                     Impact = "Potential memory leak or cache configuration issue",
-                    Suggestions = new[]
-                    {
+                    Suggestions =
+                    [
                         "Monitor for memory leaks in cached objects",
                         "Review cache expiration policies",
                         "Implement periodic cache cleanup",
                         "Consider implementing cache size limits"
-                    }
+                    ]
                 });
             }
         }
@@ -195,7 +194,7 @@ public class CacheOptimizationAnalyzer : IDisposable
 
     private async Task<IEnumerable<OptimizationRecommendation>> AnalyzeHotKeysAsync()
     {
-        if (_intelligentCacheManager == null) return Array.Empty<OptimizationRecommendation>();
+        if (_intelligentCacheManager == null) return [];
         
         var recommendations = new List<OptimizationRecommendation>();
         
@@ -216,13 +215,13 @@ public class CacheOptimizationAnalyzer : IDisposable
                     Title = "Multiple Hot Keys Detected",
                     Description = $"Detected {hotKeyList.Count} hot keys with average access rate of {avgAccessRate:F1}/min",
                     Impact = "Hot keys may cause cache contention and uneven load distribution",
-                    Suggestions = new[]
-                    {
+                    Suggestions =
+                    [
                         "Consider implementing cache warming for hot keys",
                         "Extend TTL for frequently accessed hot keys",
                         "Implement key sharding for extremely hot keys",
                         "Monitor for thundering herd patterns"
-                    },
+                    ],
                     Metrics = new Dictionary<string, object>
                     {
                         { "hot_keys_count", hotKeyList.Count },
@@ -243,13 +242,13 @@ public class CacheOptimizationAnalyzer : IDisposable
                     Title = "Extremely Hot Keys Detected",
                     Description = $"Found {extremelyHotKeys.Count} keys with >100 accesses/minute",
                     Impact = "Extremely hot keys can become performance bottlenecks",
-                    Suggestions = new[]
-                    {
+                    Suggestions =
+                    [
                         "Implement local caching layer for extremely hot keys",
                         "Consider read replicas or CDN for hot data",
                         "Review data access patterns for optimization opportunities",
                         "Implement circuit breaker pattern for hot key protection"
-                    },
+                    ],
                     Metrics = new Dictionary<string, object>
                     {
                         { "extreme_hot_keys", extremelyHotKeys.Select(k => new { k.Key, k.AccessRate }).ToArray() }
@@ -285,13 +284,13 @@ public class CacheOptimizationAnalyzer : IDisposable
                 Title = "Performance Degradation Trend",
                 Description = "Cache performance has been declining over time",
                 Impact = $"Performance declined by {((historicalPerformance - recentPerformance) / historicalPerformance * 100):F1}%",
-                Suggestions = new[]
-                {
+                Suggestions =
+                [
                     "Investigate root cause of performance decline",
                     "Review recent configuration changes",
                     "Check for resource constraints (CPU, memory, network)",
                     "Consider performance tuning or hardware upgrades"
-                }
+                ]
             });
         }
 
@@ -317,13 +316,13 @@ public class CacheOptimizationAnalyzer : IDisposable
                 Title = "Increasing Error Rate",
                 Description = "Cache error rate has significantly increased",
                 Impact = "High error rates can impact application reliability",
-                Suggestions = new[]
-                {
+                Suggestions =
+                [
                     "Investigate error logs for root cause analysis",
                     "Check cache backend connectivity and health",
                     "Review error handling and retry policies",
                     "Consider implementing circuit breaker patterns"
-                },
+                ],
                 Metrics = new Dictionary<string, object>
                 {
                     { "recent_error_rate", recentErrors },
@@ -434,7 +433,7 @@ public class OptimizationReport
 {
     public DateTime GeneratedAt { get; init; }
     public CachePerformanceSnapshot CurrentSnapshot { get; init; } = new();
-    public OptimizationRecommendation[] Recommendations { get; init; } = Array.Empty<OptimizationRecommendation>();
+    public OptimizationRecommendation[] Recommendations { get; init; } = [];
     public string Summary { get; init; } = string.Empty;
 }
 
@@ -445,7 +444,7 @@ public class OptimizationRecommendation
     public string Title { get; init; } = string.Empty;
     public string Description { get; init; } = string.Empty;
     public string Impact { get; init; } = string.Empty;
-    public string[] Suggestions { get; init; } = Array.Empty<string>();
+    public string[] Suggestions { get; init; } = [];
     public Dictionary<string, object>? Metrics { get; init; }
     public DateTime CreatedAt { get; init; } = DateTime.UtcNow;
 }

--- a/Athena.Cache.Core/Analytics/CacheOptimizationAnalyzer.cs
+++ b/Athena.Cache.Core/Analytics/CacheOptimizationAnalyzer.cs
@@ -1,0 +1,481 @@
+using Athena.Cache.Core.Abstractions;
+using Athena.Cache.Core.Observability;
+using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
+
+namespace Athena.Cache.Core.Analytics;
+
+/// <summary>
+/// 캐시 성능 분석 및 최적화 제안 엔진
+/// </summary>
+public class CacheOptimizationAnalyzer : IDisposable
+{
+    private readonly IIntelligentCacheManager? _intelligentCacheManager;
+    private readonly CacheHealthMonitor _healthMonitor;
+    private readonly ILogger<CacheOptimizationAnalyzer> _logger;
+    
+    private readonly Timer _analysisTimer;
+    private readonly ConcurrentQueue<OptimizationRecommendation> _recommendations = new();
+    private readonly ConcurrentDictionary<string, PatternAnalysis> _patterns = new();
+    
+    private volatile bool _disposed = false;
+
+    public CacheOptimizationAnalyzer(
+        CacheHealthMonitor healthMonitor,
+        ILogger<CacheOptimizationAnalyzer> logger,
+        IIntelligentCacheManager? intelligentCacheManager = null)
+    {
+        _healthMonitor = healthMonitor ?? throw new ArgumentNullException(nameof(healthMonitor));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _intelligentCacheManager = intelligentCacheManager;
+
+        // 10분마다 분석 실행
+        _analysisTimer = new Timer(PerformAnalysis, null, TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(10));
+        
+        _logger.LogInformation("CacheOptimizationAnalyzer initialized");
+    }
+
+    #region Analysis Methods
+
+    public async Task<OptimizationReport> GenerateOptimizationReportAsync()
+    {
+        var currentSnapshot = _healthMonitor.GetCurrentSnapshot();
+        var performanceHistory = _healthMonitor.GetPerformanceHistory(60).ToList();
+        
+        var recommendations = new List<OptimizationRecommendation>();
+        
+        // 1. Hit Rate 분석
+        recommendations.AddRange(await AnalyzeHitRateAsync(currentSnapshot, performanceHistory));
+        
+        // 2. Memory Usage 분석
+        recommendations.AddRange(AnalyzeMemoryUsage(currentSnapshot, performanceHistory));
+        
+        // 3. Hot Key 분석
+        if (_intelligentCacheManager != null)
+        {
+            recommendations.AddRange(await AnalyzeHotKeysAsync());
+        }
+        
+        // 4. Performance Trend 분석
+        recommendations.AddRange(AnalyzePerformanceTrends(performanceHistory));
+        
+        // 5. Error Pattern 분석
+        recommendations.AddRange(AnalyzeErrorPatterns(performanceHistory));
+
+        return new OptimizationReport
+        {
+            GeneratedAt = DateTime.UtcNow,
+            CurrentSnapshot = currentSnapshot,
+            Recommendations = recommendations.OrderByDescending(r => r.Priority).ToArray(),
+            Summary = GenerateReportSummary(recommendations, currentSnapshot)
+        };
+    }
+
+    private async Task<IEnumerable<OptimizationRecommendation>> AnalyzeHitRateAsync(
+        CachePerformanceSnapshot snapshot, 
+        List<CachePerformanceSnapshot> history)
+    {
+        var recommendations = new List<OptimizationRecommendation>();
+        
+        // Hit Rate가 낮은 경우
+        if (snapshot.HitRatio < 0.7)
+        {
+            var trend = CalculateHitRateTrend(history);
+            
+            recommendations.Add(new OptimizationRecommendation
+            {
+                Type = OptimizationType.HitRateImprovement,
+                Priority = OptimizationPriority.High,
+                Title = "Low Cache Hit Rate Detected",
+                Description = $"Current hit rate is {snapshot.HitRatio:P1}, which is below optimal threshold of 70%",
+                Impact = EstimateHitRateImpact(snapshot.HitRatio),
+                Suggestions = new[]
+                {
+                    "Consider increasing cache TTL for frequently accessed data",
+                    "Review cache key patterns for better cache locality",
+                    "Implement cache warming for predictable access patterns",
+                    "Analyze and optimize cache eviction policies"
+                },
+                Metrics = new Dictionary<string, object>
+                {
+                    { "current_hit_rate", snapshot.HitRatio },
+                    { "trend", trend },
+                    { "target_hit_rate", 0.8 }
+                }
+            });
+        }
+        
+        // Hit Rate가 급격히 감소하는 경우
+        if (history.Count >= 10)
+        {
+            var recentAvg = history.Skip(history.Count - 5).Average(h => h.HitRatio);
+            var historicalAvg = history.Take(history.Count - 5).Average(h => h.HitRatio);
+            
+            if (recentAvg < historicalAvg * 0.8) // 20% 이상 감소
+            {
+                recommendations.Add(new OptimizationRecommendation
+                {
+                    Type = OptimizationType.PerformanceDegradation,
+                    Priority = OptimizationPriority.Critical,
+                    Title = "Significant Hit Rate Degradation",
+                    Description = $"Hit rate dropped from {historicalAvg:P1} to {recentAvg:P1}",
+                    Impact = $"Estimated {(historicalAvg - recentAvg) * 100:F0}% performance impact",
+                    Suggestions = new[]
+                    {
+                        "Investigate recent changes in data access patterns",
+                        "Check for memory pressure causing premature evictions",
+                        "Review recent application deployments or configuration changes",
+                        "Consider emergency cache warming to restore performance"
+                    }
+                });
+            }
+        }
+
+        return recommendations;
+    }
+
+    private IEnumerable<OptimizationRecommendation> AnalyzeMemoryUsage(
+        CachePerformanceSnapshot snapshot, 
+        List<CachePerformanceSnapshot> history)
+    {
+        var recommendations = new List<OptimizationRecommendation>();
+        
+        // Memory usage가 높은 경우
+        var memoryMB = snapshot.MemoryUsageBytes / (1024.0 * 1024.0);
+        if (memoryMB > 1000) // 1GB 이상
+        {
+            recommendations.Add(new OptimizationRecommendation
+            {
+                Type = OptimizationType.MemoryOptimization,
+                Priority = OptimizationPriority.Medium,
+                Title = "High Memory Usage",
+                Description = $"Cache is using {memoryMB:F0}MB of memory",
+                Impact = "High memory usage may impact system performance",
+                Suggestions = new[]
+                {
+                    "Implement more aggressive cache eviction policies",
+                    "Reduce TTL for less critical cached data",
+                    "Consider compressing cached values",
+                    "Review cache size limits and adjust accordingly"
+                },
+                Metrics = new Dictionary<string, object>
+                {
+                    { "memory_usage_mb", memoryMB },
+                    { "item_count", snapshot.ItemCount }
+                }
+            });
+        }
+        
+        // Memory 사용량이 급증하는 경우
+        if (history.Count >= 5)
+        {
+            var memoryTrend = CalculateMemoryTrend(history);
+            if (memoryTrend > 0.2) // 20% 이상 증가 트렌드
+            {
+                recommendations.Add(new OptimizationRecommendation
+                {
+                    Type = OptimizationType.MemoryLeak,
+                    Priority = OptimizationPriority.High,
+                    Title = "Memory Usage Increasing Trend",
+                    Description = "Memory usage is consistently increasing",
+                    Impact = "Potential memory leak or cache configuration issue",
+                    Suggestions = new[]
+                    {
+                        "Monitor for memory leaks in cached objects",
+                        "Review cache expiration policies",
+                        "Implement periodic cache cleanup",
+                        "Consider implementing cache size limits"
+                    }
+                });
+            }
+        }
+
+        return recommendations;
+    }
+
+    private async Task<IEnumerable<OptimizationRecommendation>> AnalyzeHotKeysAsync()
+    {
+        if (_intelligentCacheManager == null) return Array.Empty<OptimizationRecommendation>();
+        
+        var recommendations = new List<OptimizationRecommendation>();
+        
+        try
+        {
+            var hotKeys = await _intelligentCacheManager.GetHotKeysAsync(20);
+            var hotKeyList = hotKeys.ToList();
+            
+            if (hotKeyList.Count > 10) // 많은 Hot Key 감지
+            {
+                var topHotKeys = hotKeyList.Take(5).ToList();
+                var avgAccessRate = topHotKeys.Average(k => k.AccessRate);
+                
+                recommendations.Add(new OptimizationRecommendation
+                {
+                    Type = OptimizationType.HotKeyOptimization,
+                    Priority = OptimizationPriority.Medium,
+                    Title = "Multiple Hot Keys Detected",
+                    Description = $"Detected {hotKeyList.Count} hot keys with average access rate of {avgAccessRate:F1}/min",
+                    Impact = "Hot keys may cause cache contention and uneven load distribution",
+                    Suggestions = new[]
+                    {
+                        "Consider implementing cache warming for hot keys",
+                        "Extend TTL for frequently accessed hot keys",
+                        "Implement key sharding for extremely hot keys",
+                        "Monitor for thundering herd patterns"
+                    },
+                    Metrics = new Dictionary<string, object>
+                    {
+                        { "hot_keys_count", hotKeyList.Count },
+                        { "top_hot_keys", topHotKeys.Select(k => new { k.Key, k.AccessRate }).ToArray() },
+                        { "average_access_rate", avgAccessRate }
+                    }
+                });
+            }
+            
+            // 극도로 핫한 키 감지
+            var extremelyHotKeys = hotKeyList.Where(k => k.AccessRate > 100).ToList(); // 100회/분 이상
+            if (extremelyHotKeys.Any())
+            {
+                recommendations.Add(new OptimizationRecommendation
+                {
+                    Type = OptimizationType.PerformanceBottleneck,
+                    Priority = OptimizationPriority.High,  
+                    Title = "Extremely Hot Keys Detected",
+                    Description = $"Found {extremelyHotKeys.Count} keys with >100 accesses/minute",
+                    Impact = "Extremely hot keys can become performance bottlenecks",
+                    Suggestions = new[]
+                    {
+                        "Implement local caching layer for extremely hot keys",
+                        "Consider read replicas or CDN for hot data",
+                        "Review data access patterns for optimization opportunities",
+                        "Implement circuit breaker pattern for hot key protection"
+                    },
+                    Metrics = new Dictionary<string, object>
+                    {
+                        { "extreme_hot_keys", extremelyHotKeys.Select(k => new { k.Key, k.AccessRate }).ToArray() }
+                    }
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to analyze hot keys");
+        }
+
+        return recommendations;
+    }
+
+    private IEnumerable<OptimizationRecommendation> AnalyzePerformanceTrends(
+        List<CachePerformanceSnapshot> history)
+    {
+        var recommendations = new List<OptimizationRecommendation>();
+        
+        if (history.Count < 10) return recommendations;
+
+        // 성능 저하 트렌드 분석
+        var recentPerformance = history.Skip(history.Count - 5).Average(h => h.HitRatio);
+        var historicalPerformance = history.Take(history.Count - 5).Average(h => h.HitRatio);
+        
+        if (recentPerformance < historicalPerformance * 0.9) // 10% 이상 성능 저하
+        {
+            recommendations.Add(new OptimizationRecommendation
+            {
+                Type = OptimizationType.PerformanceDegradation,
+                Priority = OptimizationPriority.High,
+                Title = "Performance Degradation Trend",
+                Description = "Cache performance has been declining over time",
+                Impact = $"Performance declined by {((historicalPerformance - recentPerformance) / historicalPerformance * 100):F1}%",
+                Suggestions = new[]
+                {
+                    "Investigate root cause of performance decline",
+                    "Review recent configuration changes",
+                    "Check for resource constraints (CPU, memory, network)",
+                    "Consider performance tuning or hardware upgrades"
+                }
+            });
+        }
+
+        return recommendations;
+    }
+
+    private IEnumerable<OptimizationRecommendation> AnalyzeErrorPatterns(
+        List<CachePerformanceSnapshot> history)
+    {
+        var recommendations = new List<OptimizationRecommendation>();
+        
+        if (history.Count < 5) return recommendations;
+
+        var recentErrors = history.Skip(history.Count - 5).Average(h => h.TotalErrors);
+        var historicalErrors = history.Take(history.Count - 5).Average(h => h.TotalErrors);
+        
+        if (recentErrors > historicalErrors * 2 && recentErrors > 10) // 에러가 2배 이상 증가
+        {
+            recommendations.Add(new OptimizationRecommendation
+            {
+                Type = OptimizationType.ErrorReduction,
+                Priority = OptimizationPriority.Critical,
+                Title = "Increasing Error Rate",
+                Description = "Cache error rate has significantly increased",
+                Impact = "High error rates can impact application reliability",
+                Suggestions = new[]
+                {
+                    "Investigate error logs for root cause analysis",
+                    "Check cache backend connectivity and health",
+                    "Review error handling and retry policies",
+                    "Consider implementing circuit breaker patterns"
+                },
+                Metrics = new Dictionary<string, object>
+                {
+                    { "recent_error_rate", recentErrors },
+                    { "historical_error_rate", historicalErrors }
+                }
+            });
+        }
+
+        return recommendations;
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private double CalculateHitRateTrend(List<CachePerformanceSnapshot> history)
+    {
+        if (history.Count < 5) return 0;
+        
+        var recent = history.Skip(history.Count - 5).Average(h => h.HitRatio);
+        var historical = history.Take(history.Count - 5).Average(h => h.HitRatio);
+        
+        return recent - historical;
+    }
+
+    private double CalculateMemoryTrend(List<CachePerformanceSnapshot> history)
+    {
+        if (history.Count < 5) return 0;
+        
+        var recent = history.Skip(history.Count - 5).Average(h => h.MemoryUsageBytes);
+        var historical = history.Take(history.Count - 5).Average(h => h.MemoryUsageBytes);
+        
+        return (recent - historical) / Math.Max(historical, 1);
+    }
+
+    private string EstimateHitRateImpact(double currentHitRate)
+    {
+        var optimalHitRate = 0.8;
+        var improvementPotential = optimalHitRate - currentHitRate;
+        var estimatedSpeedupPercent = improvementPotential * 100;
+        
+        return $"Improving hit rate could reduce response time by ~{estimatedSpeedupPercent:F0}%";
+    }
+
+    private string GenerateReportSummary(List<OptimizationRecommendation> recommendations, CachePerformanceSnapshot snapshot)
+    {
+        var critical = recommendations.Count(r => r.Priority == OptimizationPriority.Critical);
+        var high = recommendations.Count(r => r.Priority == OptimizationPriority.High);
+        var medium = recommendations.Count(r => r.Priority == OptimizationPriority.Medium);
+        
+        return $"Hit Rate: {snapshot.HitRatio:P1} | Memory: {snapshot.MemoryUsageBytes / (1024.0 * 1024.0):F0}MB | " +
+               $"Recommendations: {critical} Critical, {high} High, {medium} Medium";
+    }
+
+    private void PerformAnalysis(object? state)
+    {
+        if (_disposed) return;
+
+        Task.Run(async () =>
+        {
+            try
+            {
+                var report = await GenerateOptimizationReportAsync();
+                
+                // 중요한 권고사항이 있으면 로그
+                var criticalRecommendations = report.Recommendations.Where(r => r.Priority == OptimizationPriority.Critical).ToArray();
+                if (criticalRecommendations.Any())
+                {
+                    _logger.LogWarning("Critical cache optimization recommendations: {Count} issues detected", 
+                        criticalRecommendations.Length);
+                    
+                    foreach (var rec in criticalRecommendations)
+                    {
+                        _logger.LogWarning("Critical: {Title} - {Description}", rec.Title, rec.Description);
+                    }
+                }
+                
+                // 최근 권고사항 저장 (최대 100개)
+                _recommendations.Enqueue(report.Recommendations.FirstOrDefault() ?? new OptimizationRecommendation());
+                while (_recommendations.Count > 100)
+                {
+                    _recommendations.TryDequeue(out _);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during cache optimization analysis");
+            }
+        });
+    }
+
+    #endregion
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+
+        _analysisTimer?.Dispose();
+        _disposed = true;
+        
+        _logger.LogInformation("CacheOptimizationAnalyzer disposed");
+    }
+}
+
+#region Models
+
+public class OptimizationReport
+{
+    public DateTime GeneratedAt { get; init; }
+    public CachePerformanceSnapshot CurrentSnapshot { get; init; } = new();
+    public OptimizationRecommendation[] Recommendations { get; init; } = Array.Empty<OptimizationRecommendation>();
+    public string Summary { get; init; } = string.Empty;
+}
+
+public class OptimizationRecommendation
+{
+    public OptimizationType Type { get; init; }
+    public OptimizationPriority Priority { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string Description { get; init; } = string.Empty;
+    public string Impact { get; init; } = string.Empty;
+    public string[] Suggestions { get; init; } = Array.Empty<string>();
+    public Dictionary<string, object>? Metrics { get; init; }
+    public DateTime CreatedAt { get; init; } = DateTime.UtcNow;
+}
+
+public enum OptimizationType
+{
+    HitRateImprovement,
+    MemoryOptimization,
+    MemoryLeak,
+    HotKeyOptimization,
+    PerformanceBottleneck,
+    PerformanceDegradation,
+    ErrorReduction
+}
+
+public enum OptimizationPriority
+{
+    Low,
+    Medium,
+    High,
+    Critical
+}
+
+public class PatternAnalysis
+{
+    public string Pattern { get; init; } = string.Empty;
+    public long AccessCount { get; init; }
+    public DateTime FirstSeen { get; init; }
+    public DateTime LastSeen { get; init; }
+    public double Frequency { get; init; }
+}
+
+#endregion

--- a/Athena.Cache.Core/Athena.Cache.Core.csproj
+++ b/Athena.Cache.Core/Athena.Cache.Core.csproj
@@ -29,6 +29,9 @@
 		<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.3.0" />
 		<PackageReference Include="System.Text.Json" Version="9.0.7" />
+		<PackageReference Include="MessagePack" Version="2.5.187" />
+		<PackageReference Include="MessagePack.Annotations" Version="2.5.187" />
+		<PackageReference Include="System.IO.Hashing" Version="9.0.7" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/Athena.Cache.Core/Attributes/NoCacheAttribute.cs
+++ b/Athena.Cache.Core/Attributes/NoCacheAttribute.cs
@@ -4,6 +4,4 @@
 /// 캐시 비활성화 Attribute (특정 액션만 제외하고 싶을 때)
 /// </summary>
 [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-public class NoCacheAttribute : Attribute
-{
-}
+public class NoCacheAttribute : Attribute;

--- a/Athena.Cache.Core/Attributes/NoConventionInvalidationAttribute.cs
+++ b/Athena.Cache.Core/Attributes/NoConventionInvalidationAttribute.cs
@@ -1,0 +1,11 @@
+﻿namespace Athena.Cache.Core.Attributes;
+
+/// <summary>
+/// Convention 기반 테이블명 추론을 비활성화하는 Attribute
+/// 이 어트리뷰트가 적용된 컨트롤러/액션은 명시적으로 선언된 CacheInvalidateOn만 사용하고,
+/// Convention 기반 자동 추론은 수행하지 않습니다.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public class NoConventionInvalidationAttribute : Attribute
+{
+}

--- a/Athena.Cache.Core/Configuration/AthenaCacheOptions.cs
+++ b/Athena.Cache.Core/Configuration/AthenaCacheOptions.cs
@@ -39,4 +39,25 @@ public class AthenaCacheOptions
 
     /// <summary>에러 처리 옵션</summary>
     public ErrorHandlingOptions ErrorHandling { get; set; } = new();
+
+    /// <summary>Circuit Breaker 설정</summary>
+    public CircuitBreakerOptions? CircuitBreaker { get; set; }
+}
+
+/// <summary>
+/// Circuit Breaker 설정 옵션
+/// </summary>
+public class CircuitBreakerOptions
+{
+    /// <summary>Circuit을 Open하기 위한 연속 실패 임계치</summary>
+    public int FailureThreshold { get; set; } = 5;
+    
+    /// <summary>Open 상태에서 Half-Open으로 전환하기 위한 대기 시간</summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromMinutes(1);
+    
+    /// <summary>헬스 체크 주기</summary>
+    public TimeSpan HealthCheckInterval { get; set; } = TimeSpan.FromSeconds(30);
+    
+    /// <summary>메트릭 보존 기간</summary>
+    public TimeSpan MetricRetentionPeriod { get; set; } = TimeSpan.FromHours(1);
 }

--- a/Athena.Cache.Core/Configuration/ConventionOptions.cs
+++ b/Athena.Cache.Core/Configuration/ConventionOptions.cs
@@ -14,6 +14,15 @@ public class ConventionOptions
     /// <summary>Humanizer 라이브러리 사용</summary>
     public bool UseHumanizer { get; set; } = false;
 
-    /// <summary>커스텀 복수형 변환 함수</summary>
+    /// <summary>커스텀 복수형 변환 함수 (단일 테이블)</summary>
     public Func<string, string>? CustomPluralizer { get; set; }
+
+    /// <summary>커스텀 다중 테이블 추론 함수</summary>
+    public Func<string, string[]>? CustomMultiTableInferrer { get; set; }
+
+    /// <summary>컨트롤러별 테이블 매핑 사전 (컨트롤러명 → 테이블명 배열)</summary>
+    public Dictionary<string, string[]> ControllerTableMappings { get; set; } = new();
+
+    /// <summary>Convention 기반 추론에서 제외할 컨트롤러명 목록</summary>
+    public HashSet<string> ExcludedControllers { get; set; } = new();
 }

--- a/Athena.Cache.Core/Controllers/CacheMonitoringController.cs
+++ b/Athena.Cache.Core/Controllers/CacheMonitoringController.cs
@@ -12,18 +12,13 @@ namespace Athena.Cache.Core.Controllers;
 [ApiController]
 [Route("api/athena-cache/monitoring")]
 [Authorize(Policy = "AthenaCacheMonitoring")] // 보안을 위한 인증 필요
-public class CacheMonitoringController : ControllerBase
+public class CacheMonitoringController(
+    CacheHealthMonitor healthMonitor,
+    ILogger<CacheMonitoringController> logger)
+    : ControllerBase
 {
-    private readonly CacheHealthMonitor _healthMonitor;
-    private readonly ILogger<CacheMonitoringController> _logger;
-
-    public CacheMonitoringController(
-        CacheHealthMonitor healthMonitor,
-        ILogger<CacheMonitoringController> logger)
-    {
-        _healthMonitor = healthMonitor ?? throw new ArgumentNullException(nameof(healthMonitor));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-    }
+    private readonly CacheHealthMonitor _healthMonitor = healthMonitor ?? throw new ArgumentNullException(nameof(healthMonitor));
+    private readonly ILogger<CacheMonitoringController> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
     /// <summary>
     /// 전체 캐시 헬스 상태 조회 (기본 기능)

--- a/Athena.Cache.Core/Controllers/CacheMonitoringController.cs
+++ b/Athena.Cache.Core/Controllers/CacheMonitoringController.cs
@@ -1,0 +1,229 @@
+using Athena.Cache.Core.Analytics;
+using Athena.Cache.Core.Observability;
+using Athena.Cache.Core.Resilience;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Athena.Cache.Core.Controllers;
+
+/// <summary>
+/// 실시간 캐시 상태 모니터링 API
+/// </summary>
+[ApiController]
+[Route("api/athena-cache/monitoring")]
+[Authorize(Policy = "AthenaCacheMonitoring")] // 보안을 위한 인증 필요
+public class CacheMonitoringController : ControllerBase
+{
+    private readonly CacheHealthMonitor _healthMonitor;
+    private readonly CacheOptimizationAnalyzer _optimizationAnalyzer;
+    private readonly CacheCircuitBreaker _circuitBreaker;
+    private readonly ILogger<CacheMonitoringController> _logger;
+
+    public CacheMonitoringController(
+        CacheHealthMonitor healthMonitor,
+        CacheOptimizationAnalyzer optimizationAnalyzer,
+        CacheCircuitBreaker circuitBreaker,
+        ILogger<CacheMonitoringController> logger)
+    {
+        _healthMonitor = healthMonitor ?? throw new ArgumentNullException(nameof(healthMonitor));
+        _optimizationAnalyzer = optimizationAnalyzer ?? throw new ArgumentNullException(nameof(optimizationAnalyzer));
+        _circuitBreaker = circuitBreaker ?? throw new ArgumentNullException(nameof(circuitBreaker));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// 전체 캐시 헬스 상태 조회
+    /// </summary>
+    [HttpGet("health")]
+    public async Task<ActionResult<OverallHealthStatus>> GetHealthStatus()
+    {
+        try
+        {
+            var healthStatus = await _healthMonitor.GetOverallHealthAsync();
+            return Ok(healthStatus);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get cache health status");
+            return StatusCode(500, new { error = "Failed to retrieve health status", details = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// 실시간 성능 메트릭 조회
+    /// </summary>
+    [HttpGet("metrics/current")]
+    public ActionResult<CachePerformanceSnapshot> GetCurrentMetrics()
+    {
+        try
+        {
+            var snapshot = _healthMonitor.GetCurrentSnapshot();
+            return Ok(snapshot);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get current cache metrics");
+            return StatusCode(500, new { error = "Failed to retrieve current metrics", details = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// 성능 히스토리 조회
+    /// </summary>
+    [HttpGet("metrics/history")]
+    public ActionResult<IEnumerable<CachePerformanceSnapshot>> GetMetricsHistory(
+        [FromQuery] int maxItems = 60)
+    {
+        try
+        {
+            if (maxItems <= 0 || maxItems > 1440) // 최대 24시간
+            {
+                return BadRequest(new { error = "maxItems must be between 1 and 1440" });
+            }
+
+            var history = _healthMonitor.GetPerformanceHistory(maxItems);
+            return Ok(history);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get cache metrics history");
+            return StatusCode(500, new { error = "Failed to retrieve metrics history", details = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// 최적화 보고서 생성
+    /// </summary>
+    [HttpGet("optimization-report")]
+    public async Task<ActionResult<OptimizationReport>> GetOptimizationReport()
+    {
+        try
+        {
+            var report = await _optimizationAnalyzer.GenerateOptimizationReportAsync();
+            return Ok(report);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to generate optimization report");
+            return StatusCode(500, new { error = "Failed to generate optimization report", details = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Circuit Breaker 상태 조회
+    /// </summary>
+    [HttpGet("circuit-breaker/status")]
+    public ActionResult<CircuitBreakerStatistics> GetCircuitBreakerStatus()
+    {
+        try
+        {
+            var statistics = _circuitBreaker.GetStatistics();
+            return Ok(statistics);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get circuit breaker status");
+            return StatusCode(500, new { error = "Failed to retrieve circuit breaker status", details = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// 실시간 대시보드 데이터 (WebSocket용)
+    /// </summary>
+    [HttpGet("dashboard/realtime")]
+    public async Task<ActionResult<DashboardData>> GetRealtimeDashboardData()
+    {
+        try
+        {
+            var healthStatus = await _healthMonitor.GetOverallHealthAsync();
+            var currentMetrics = _healthMonitor.GetCurrentSnapshot();
+            var circuitBreakerStats = _circuitBreaker.GetStatistics();
+
+            var dashboardData = new DashboardData
+            {
+                Timestamp = DateTime.UtcNow,
+                HealthStatus = healthStatus,
+                CurrentMetrics = currentMetrics,
+                CircuitBreakerStatus = circuitBreakerStats,
+                RecentHistory = _healthMonitor.GetPerformanceHistory(10).ToArray()
+            };
+
+            return Ok(dashboardData);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get realtime dashboard data");
+            return StatusCode(500, new { error = "Failed to retrieve dashboard data", details = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// 캐시 통계 요약
+    /// </summary>
+    [HttpGet("summary")]
+    public async Task<ActionResult<CacheSummary>> GetCacheSummary()
+    {
+        try
+        {
+            var healthStatus = await _healthMonitor.GetOverallHealthAsync();
+            var currentMetrics = _healthMonitor.GetCurrentSnapshot();
+            var history = _healthMonitor.GetPerformanceHistory(60).ToList();
+
+            var summary = new CacheSummary
+            {
+                GeneratedAt = DateTime.UtcNow,
+                OverallStatus = healthStatus.Status,
+                CurrentHitRatio = currentMetrics.HitRatio,
+                TotalHits = currentMetrics.TotalHits,
+                TotalMisses = currentMetrics.TotalMisses,
+                MemoryUsageMB = currentMetrics.MemoryUsageBytes / (1024.0 * 1024.0),
+                ItemCount = currentMetrics.ItemCount,
+                HotKeysCount = currentMetrics.HotKeysCount,
+                TotalErrors = currentMetrics.TotalErrors,
+                AverageHitRatioLast60Min = history.Any() ? history.Average(h => h.HitRatio) : 0,
+                CircuitBreakerState = _circuitBreaker.State
+            };
+
+            return Ok(summary);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get cache summary");
+            return StatusCode(500, new { error = "Failed to retrieve cache summary", details = ex.Message });
+        }
+    }
+}
+
+#region Response Models
+
+/// <summary>
+/// 실시간 대시보드 데이터
+/// </summary>
+public class DashboardData
+{
+    public DateTime Timestamp { get; init; }
+    public OverallHealthStatus HealthStatus { get; init; } = new();
+    public CachePerformanceSnapshot CurrentMetrics { get; init; } = new();
+    public CircuitBreakerStatistics CircuitBreakerStatus { get; init; } = new();
+    public CachePerformanceSnapshot[] RecentHistory { get; init; } = Array.Empty<CachePerformanceSnapshot>();
+}
+
+/// <summary>
+/// 캐시 통계 요약
+/// </summary>
+public class CacheSummary
+{
+    public DateTime GeneratedAt { get; init; }
+    public HealthStatus OverallStatus { get; init; }
+    public double CurrentHitRatio { get; init; }
+    public long TotalHits { get; init; }
+    public long TotalMisses { get; init; }
+    public double MemoryUsageMB { get; init; }
+    public long ItemCount { get; init; }
+    public long HotKeysCount { get; init; }
+    public long TotalErrors { get; init; }
+    public double AverageHitRatioLast60Min { get; init; }
+    public CircuitBreakerState CircuitBreakerState { get; init; }
+}
+
+#endregion

--- a/Athena.Cache.Core/Controllers/CacheMonitoringController.cs
+++ b/Athena.Cache.Core/Controllers/CacheMonitoringController.cs
@@ -1,13 +1,13 @@
-using Athena.Cache.Core.Analytics;
+using Athena.Cache.Core.Abstractions;
 using Athena.Cache.Core.Observability;
-using Athena.Cache.Core.Resilience;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Athena.Cache.Core.Controllers;
 
 /// <summary>
-/// 실시간 캐시 상태 모니터링 API
+/// 기본 캐시 모니터링 API - 핵심 기능만 제공
+/// 고급 대시보드 기능은 Athena.Cache.Monitoring 라이브러리 사용
 /// </summary>
 [ApiController]
 [Route("api/athena-cache/monitoring")]
@@ -15,24 +15,18 @@ namespace Athena.Cache.Core.Controllers;
 public class CacheMonitoringController : ControllerBase
 {
     private readonly CacheHealthMonitor _healthMonitor;
-    private readonly CacheOptimizationAnalyzer _optimizationAnalyzer;
-    private readonly CacheCircuitBreaker _circuitBreaker;
     private readonly ILogger<CacheMonitoringController> _logger;
 
     public CacheMonitoringController(
         CacheHealthMonitor healthMonitor,
-        CacheOptimizationAnalyzer optimizationAnalyzer,
-        CacheCircuitBreaker circuitBreaker,
         ILogger<CacheMonitoringController> logger)
     {
         _healthMonitor = healthMonitor ?? throw new ArgumentNullException(nameof(healthMonitor));
-        _optimizationAnalyzer = optimizationAnalyzer ?? throw new ArgumentNullException(nameof(optimizationAnalyzer));
-        _circuitBreaker = circuitBreaker ?? throw new ArgumentNullException(nameof(circuitBreaker));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     /// <summary>
-    /// 전체 캐시 헬스 상태 조회
+    /// 전체 캐시 헬스 상태 조회 (기본 기능)
     /// </summary>
     [HttpGet("health")]
     public async Task<ActionResult<OverallHealthStatus>> GetHealthStatus()
@@ -50,10 +44,10 @@ public class CacheMonitoringController : ControllerBase
     }
 
     /// <summary>
-    /// 실시간 성능 메트릭 조회
+    /// 현재 성능 메트릭 조회 (기본 기능)
     /// </summary>
     [HttpGet("metrics/current")]
-    public ActionResult<CachePerformanceSnapshot> GetCurrentMetrics()
+    public ActionResult<ICacheMetrics> GetCurrentMetrics()
     {
         try
         {
@@ -68,162 +62,34 @@ public class CacheMonitoringController : ControllerBase
     }
 
     /// <summary>
-    /// 성능 히스토리 조회
+    /// 기본 상태 확인 - 간단한 Alive 체크
     /// </summary>
-    [HttpGet("metrics/history")]
-    public ActionResult<IEnumerable<CachePerformanceSnapshot>> GetMetricsHistory(
-        [FromQuery] int maxItems = 60)
+    [HttpGet("status")]
+    public ActionResult<object> GetStatus()
     {
         try
         {
-            if (maxItems <= 0 || maxItems > 1440) // 최대 24시간
-            {
-                return BadRequest(new { error = "maxItems must be between 1 and 1440" });
-            }
-
-            var history = _healthMonitor.GetPerformanceHistory(maxItems);
-            return Ok(history);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to get cache metrics history");
-            return StatusCode(500, new { error = "Failed to retrieve metrics history", details = ex.Message });
-        }
-    }
-
-    /// <summary>
-    /// 최적화 보고서 생성
-    /// </summary>
-    [HttpGet("optimization-report")]
-    public async Task<ActionResult<OptimizationReport>> GetOptimizationReport()
-    {
-        try
-        {
-            var report = await _optimizationAnalyzer.GenerateOptimizationReportAsync();
-            return Ok(report);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to generate optimization report");
-            return StatusCode(500, new { error = "Failed to generate optimization report", details = ex.Message });
-        }
-    }
-
-    /// <summary>
-    /// Circuit Breaker 상태 조회
-    /// </summary>
-    [HttpGet("circuit-breaker/status")]
-    public ActionResult<CircuitBreakerStatistics> GetCircuitBreakerStatus()
-    {
-        try
-        {
-            var statistics = _circuitBreaker.GetStatistics();
-            return Ok(statistics);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to get circuit breaker status");
-            return StatusCode(500, new { error = "Failed to retrieve circuit breaker status", details = ex.Message });
-        }
-    }
-
-    /// <summary>
-    /// 실시간 대시보드 데이터 (WebSocket용)
-    /// </summary>
-    [HttpGet("dashboard/realtime")]
-    public async Task<ActionResult<DashboardData>> GetRealtimeDashboardData()
-    {
-        try
-        {
-            var healthStatus = await _healthMonitor.GetOverallHealthAsync();
             var currentMetrics = _healthMonitor.GetCurrentSnapshot();
-            var circuitBreakerStats = _circuitBreaker.GetStatistics();
-
-            var dashboardData = new DashboardData
+            
+            return Ok(new
             {
-                Timestamp = DateTime.UtcNow,
-                HealthStatus = healthStatus,
-                CurrentMetrics = currentMetrics,
-                CircuitBreakerStatus = circuitBreakerStats,
-                RecentHistory = _healthMonitor.GetPerformanceHistory(10).ToArray()
-            };
-
-            return Ok(dashboardData);
+                timestamp = DateTime.UtcNow,
+                status = "healthy",
+                hitRatio = currentMetrics.HitRatio,
+                memoryUsageMB = Math.Round(currentMetrics.MemoryUsageBytes / (1024.0 * 1024.0), 2),
+                itemCount = currentMetrics.ItemCount,
+                message = "Athena Cache is running"
+            });
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to get realtime dashboard data");
-            return StatusCode(500, new { error = "Failed to retrieve dashboard data", details = ex.Message });
-        }
-    }
-
-    /// <summary>
-    /// 캐시 통계 요약
-    /// </summary>
-    [HttpGet("summary")]
-    public async Task<ActionResult<CacheSummary>> GetCacheSummary()
-    {
-        try
-        {
-            var healthStatus = await _healthMonitor.GetOverallHealthAsync();
-            var currentMetrics = _healthMonitor.GetCurrentSnapshot();
-            var history = _healthMonitor.GetPerformanceHistory(60).ToList();
-
-            var summary = new CacheSummary
-            {
-                GeneratedAt = DateTime.UtcNow,
-                OverallStatus = healthStatus.Status,
-                CurrentHitRatio = currentMetrics.HitRatio,
-                TotalHits = currentMetrics.TotalHits,
-                TotalMisses = currentMetrics.TotalMisses,
-                MemoryUsageMB = currentMetrics.MemoryUsageBytes / (1024.0 * 1024.0),
-                ItemCount = currentMetrics.ItemCount,
-                HotKeysCount = currentMetrics.HotKeysCount,
-                TotalErrors = currentMetrics.TotalErrors,
-                AverageHitRatioLast60Min = history.Any() ? history.Average(h => h.HitRatio) : 0,
-                CircuitBreakerState = _circuitBreaker.State
-            };
-
-            return Ok(summary);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to get cache summary");
-            return StatusCode(500, new { error = "Failed to retrieve cache summary", details = ex.Message });
+            _logger.LogError(ex, "Failed to get cache status");
+            return StatusCode(500, new { 
+                timestamp = DateTime.UtcNow,
+                status = "error", 
+                message = "Cache status check failed",
+                error = ex.Message 
+            });
         }
     }
 }
-
-#region Response Models
-
-/// <summary>
-/// 실시간 대시보드 데이터
-/// </summary>
-public class DashboardData
-{
-    public DateTime Timestamp { get; init; }
-    public OverallHealthStatus HealthStatus { get; init; } = new();
-    public CachePerformanceSnapshot CurrentMetrics { get; init; } = new();
-    public CircuitBreakerStatistics CircuitBreakerStatus { get; init; } = new();
-    public CachePerformanceSnapshot[] RecentHistory { get; init; } = Array.Empty<CachePerformanceSnapshot>();
-}
-
-/// <summary>
-/// 캐시 통계 요약
-/// </summary>
-public class CacheSummary
-{
-    public DateTime GeneratedAt { get; init; }
-    public HealthStatus OverallStatus { get; init; }
-    public double CurrentHitRatio { get; init; }
-    public long TotalHits { get; init; }
-    public long TotalMisses { get; init; }
-    public double MemoryUsageMB { get; init; }
-    public long ItemCount { get; init; }
-    public long HotKeysCount { get; init; }
-    public long TotalErrors { get; init; }
-    public double AverageHitRatioLast60Min { get; init; }
-    public CircuitBreakerState CircuitBreakerState { get; init; }
-}
-
-#endregion

--- a/Athena.Cache.Core/Diagnostics/CachePerformanceMonitor.cs
+++ b/Athena.Cache.Core/Diagnostics/CachePerformanceMonitor.cs
@@ -1,0 +1,108 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Athena.Cache.Core.Diagnostics;
+
+/// <summary>
+/// 캐시 성능 모니터링 및 메트릭 수집
+/// </summary>
+public class CachePerformanceMonitor : IDisposable
+{
+    private readonly Meter _meter;
+    private readonly Counter<long> _cacheHitCounter;
+    private readonly Counter<long> _cacheMissCounter;
+    private readonly Histogram<double> _cacheOperationDuration;
+    private readonly ObservableGauge<long> _memoryUsage;
+    
+    public CachePerformanceMonitor()
+    {
+        _meter = new Meter("Athena.Cache.Core", "1.0.0");
+        
+        // 캐시 히트/미스 카운터
+        _cacheHitCounter = _meter.CreateCounter<long>(
+            name: "athena_cache_hits_total",
+            description: "Total number of cache hits");
+            
+        _cacheMissCounter = _meter.CreateCounter<long>(
+            name: "athena_cache_misses_total", 
+            description: "Total number of cache misses");
+            
+        // 캐시 작업 소요 시간
+        _cacheOperationDuration = _meter.CreateHistogram<double>(
+            name: "athena_cache_operation_duration_seconds",
+            description: "Duration of cache operations in seconds");
+            
+        // 메모리 사용량 추적
+        _memoryUsage = _meter.CreateObservableGauge<long>(
+            name: "athena_cache_memory_usage_bytes",
+            description: "Current memory usage by cache in bytes",
+            observeValue: () => GC.GetTotalMemory(false));
+    }
+    
+    /// <summary>
+    /// 캐시 히트 기록
+    /// </summary>
+    public void RecordCacheHit(string cacheType = "default")
+    {
+        _cacheHitCounter.Add(1, new KeyValuePair<string, object?>("cache_type", cacheType));
+    }
+    
+    /// <summary>
+    /// 캐시 미스 기록
+    /// </summary>
+    public void RecordCacheMiss(string cacheType = "default")
+    {
+        _cacheMissCounter.Add(1, new KeyValuePair<string, object?>("cache_type", cacheType));
+    }
+    
+    /// <summary>
+    /// 캐시 작업 소요 시간 기록
+    /// </summary>
+    public void RecordOperationDuration(TimeSpan duration, string operation, string cacheType = "default")
+    {
+        _cacheOperationDuration.Record(
+            duration.TotalSeconds,
+            new KeyValuePair<string, object?>("operation", operation),
+            new KeyValuePair<string, object?>("cache_type", cacheType));
+    }
+    
+    /// <summary>
+    /// 성능 측정을 위한 Stopwatch 래퍼
+    /// </summary>
+    public PerformanceMeasurement StartMeasurement(string operation, string cacheType = "default")
+    {
+        return new PerformanceMeasurement(this, operation, cacheType);
+    }
+    
+    public void Dispose()
+    {
+        _meter?.Dispose();
+    }
+}
+
+/// <summary>
+/// 성능 측정 헬퍼 클래스 (using 패턴 지원)
+/// </summary>
+public class PerformanceMeasurement : IDisposable
+{
+    private readonly CachePerformanceMonitor _monitor;
+    private readonly string _operation;
+    private readonly string _cacheType;
+    private readonly Stopwatch _stopwatch;
+    
+    internal PerformanceMeasurement(CachePerformanceMonitor monitor, string operation, string cacheType)
+    {
+        _monitor = monitor;
+        _operation = operation;
+        _cacheType = cacheType;
+        _stopwatch = Stopwatch.StartNew();
+    }
+    
+    public TimeSpan Elapsed => _stopwatch.Elapsed;
+    
+    public void Dispose()
+    {
+        _stopwatch.Stop();
+        _monitor.RecordOperationDuration(_stopwatch.Elapsed, _operation, _cacheType);
+    }
+}

--- a/Athena.Cache.Core/Enums/InvalidationType.cs
+++ b/Athena.Cache.Core/Enums/InvalidationType.cs
@@ -5,10 +5,18 @@
 /// </summary>
 public enum InvalidationType
 {
-    /// <summary>연관된 모든 캐시 삭제</summary>
-    All,
+    /// <summary>테이블 기반 무효화</summary>
+    Table,
+    
     /// <summary>패턴에 맞는 캐시만 삭제</summary>
     Pattern,
+    
+    /// <summary>배치 무효화</summary>
+    Batch,
+    
     /// <summary>관련 테이블들의 캐시도 함께 삭제</summary>
-    Related
+    Related,
+
+    /// <summary>연관된 모든 캐시 삭제</summary>
+    All
 }

--- a/Athena.Cache.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/Athena.Cache.Core/Extensions/ServiceCollectionExtensions.cs
@@ -1,11 +1,17 @@
 ﻿using Athena.Cache.Core.Abstractions;
+using Athena.Cache.Core.Analytics;
 using Athena.Cache.Core.Configuration;
+using Athena.Cache.Core.Diagnostics;
 using Athena.Cache.Core.Filters;
 using Athena.Cache.Core.Implementations;
 using Athena.Cache.Core.Interfaces;
 using Athena.Cache.Core.Models;
+using Athena.Cache.Core.ObjectPools;
+using Athena.Cache.Core.Observability;
+using Athena.Cache.Core.Resilience;
 using Athena.Cache.Core.Services;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.ObjectPool;
 using System.Reflection;
 
 namespace Athena.Cache.Core.Extensions;
@@ -28,6 +34,37 @@ public static class ServiceCollectionExtensions
         services.AddSingleton(options);
         services.AddSingleton<ICacheKeyGenerator, DefaultCacheKeyGenerator>();
         services.AddSingleton<ICacheInvalidator, DefaultCacheInvalidator>();
+        
+        // Object Pool 서비스 등록 (성능 최적화)
+        services.AddSingleton<ObjectPoolProvider, DefaultObjectPoolProvider>();
+        services.AddSingleton<CachedResponsePool>();
+        
+        // 성능 모니터링 서비스 등록
+        services.AddSingleton<CachePerformanceMonitor>();
+        
+        // OpenTelemetry 메트릭 시스템 등록
+        services.AddSingleton<AthenaCacheMetrics>();
+        
+        // 헬스 모니터링 시스템 등록
+        services.AddSingleton<CacheHealthMonitor>();
+        
+        // 분석 엔진 등록
+        services.AddSingleton<CacheOptimizationAnalyzer>();
+        
+        // Circuit Breaker 등록
+        services.AddSingleton(provider =>
+        {
+            var circuitBreakerOptions = new CacheCircuitBreakerOptions
+            {
+                FailureThreshold = options.CircuitBreaker?.FailureThreshold ?? 5,
+                Timeout = options.CircuitBreaker?.Timeout ?? TimeSpan.FromMinutes(1),
+                HealthCheckInterval = options.CircuitBreaker?.HealthCheckInterval ?? TimeSpan.FromSeconds(30),
+                MetricRetentionPeriod = options.CircuitBreaker?.MetricRetentionPeriod ?? TimeSpan.FromHours(1)
+            };
+            
+            var logger = provider.GetRequiredService<ILogger<CacheCircuitBreaker>>();
+            return new CacheCircuitBreaker(circuitBreakerOptions, logger);
+        });
         
         // Registry 등록 - Source Generator가 있으면 그것을 사용, 없으면 Reflection 백업
         RegisterCacheConfigurationRegistry(services);

--- a/Athena.Cache.Core/Filters/AthenaCacheActionFilter.cs
+++ b/Athena.Cache.Core/Filters/AthenaCacheActionFilter.cs
@@ -42,23 +42,57 @@ public class AthenaCacheActionFilter(ILogger<AthenaCacheActionFilter> logger) : 
             // 액션 실행
             var executedContext = await next();
 
-            // 액션 실행 후 테이블 추적 설정
+            // 액션 실행 후 HTTP 메서드별 처리
             if (executedContext.HttpContext.Items.TryGetValue("AthenaCache.Config", out var configObj) &&
                 configObj is CacheConfiguration config &&
                 config.InvalidationRules.Any())
             {
                 var invalidator = executedContext.HttpContext.RequestServices.GetService<ICacheInvalidator>();
-                var cacheKey = executedContext.HttpContext.Items["AthenaCache.GeneratedKey"] as string;
-
-                if (invalidator != null && !string.IsNullOrEmpty(cacheKey))
+                if (invalidator != null)
                 {
-                    // 캐시 키를 테이블들과 연결하여 추적
-                    var tablesToTrack = config.InvalidationRules
-                        .Select(rule => rule.TableName)
-                        .Distinct()
-                        .ToArray();
+                    var httpMethod = executedContext.HttpContext.Request.Method;
+                    
+                    if (IsGetRequest(httpMethod))
+                    {
+                        // GET 요청: 캐시 키를 테이블들과 연결하여 추적
+                        var cacheKey = executedContext.HttpContext.Items["AthenaCache.GeneratedKey"] as string;
+                        if (!string.IsNullOrEmpty(cacheKey))
+                        {
+                            var tablesToTrack = config.InvalidationRules
+                                .Select(rule => rule.TableName)
+                                .Distinct()
+                                .ToArray();
 
-                    await invalidator.TrackCacheKeyAsync(tablesToTrack, cacheKey);
+                            await invalidator.TrackCacheKeyAsync(tablesToTrack, cacheKey);
+                            
+                            if (context.HttpContext.RequestServices.GetService<AthenaCacheOptions>() is AthenaCacheOptions options &&
+                                options.Logging.LogInvalidation)
+                            {
+                                logger.LogDebug("Tracked cache key for tables [{Tables}] in {Controller}.{Action}",
+                                    string.Join(", ", tablesToTrack), config.Controller, config.Action);
+                            }
+                        }
+                    }
+                    else if (IsModifyingRequest(httpMethod))
+                    {
+                        // POST/PUT/DELETE 요청: 관련 테이블 캐시 무효화
+                        var tablesToInvalidate = config.InvalidationRules
+                            .Select(rule => rule.TableName)
+                            .Distinct()
+                            .ToArray();
+
+                        foreach (var tableName in tablesToInvalidate)
+                        {
+                            await invalidator.InvalidateAsync(tableName);
+                        }
+                        
+                        if (context.HttpContext.RequestServices.GetService<AthenaCacheOptions>() is AthenaCacheOptions options &&
+                            options.Logging.LogInvalidation)
+                        {
+                            logger.LogInformation("Invalidated cache for tables [{Tables}] after {Method} {Controller}.{Action}",
+                                string.Join(", ", tablesToInvalidate), httpMethod, config.Controller, config.Action);
+                        }
+                    }
                 }
             }
         }
@@ -76,6 +110,25 @@ public class AthenaCacheActionFilter(ILogger<AthenaCacheActionFilter> logger) : 
             .Any(fd => fd.Filter is NoCacheAttribute);
     }
 
+    /// <summary>
+    /// GET 요청인지 확인
+    /// </summary>
+    private static bool IsGetRequest(string httpMethod)
+    {
+        return string.Equals(httpMethod, "GET", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// 데이터 수정 요청인지 확인 (POST, PUT, DELETE, PATCH)
+    /// </summary>
+    private static bool IsModifyingRequest(string httpMethod)
+    {
+        return string.Equals(httpMethod, "POST", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(httpMethod, "PUT", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(httpMethod, "DELETE", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(httpMethod, "PATCH", StringComparison.OrdinalIgnoreCase);
+    }
+
     private static CacheConfiguration? BuildCacheConfiguration(ActionExecutingContext context)
     {
         var controllerName = context.Controller.GetType().Name;
@@ -88,8 +141,11 @@ public class AthenaCacheActionFilter(ILogger<AthenaCacheActionFilter> logger) : 
             return null;
         }
 
-        // CacheInvalidateOnAttribute들 수집
+        // CacheInvalidateOnAttribute들 수집 (명시적 선언)
         var invalidationAttributes = GetAttributes<CacheInvalidateOnAttribute>(context);
+
+        // Convention 기반 테이블명 추론 및 병합
+        var allInvalidationRules = MergeInvalidationRules(context, invalidationAttributes, controllerName);
 
         var config = new CacheConfiguration
         {
@@ -101,14 +157,7 @@ public class AthenaCacheActionFilter(ILogger<AthenaCacheActionFilter> logger) : 
             AdditionalKeyParameters = cacheAttribute?.AdditionalKeyParameters ?? [],
             ExcludeParameters = cacheAttribute?.ExcludeParameters ?? [],
             CustomKeyPrefix = cacheAttribute?.CustomKeyPrefix,
-            InvalidationRules = invalidationAttributes.Select(attr => new TableInvalidationRule
-            {
-                TableName = attr.TableName,
-                InvalidationType = attr.InvalidationType,
-                Pattern = attr.Pattern,
-                RelatedTables = attr.RelatedTables,
-                MaxDepth = attr.MaxDepth
-            }).ToList()
+            InvalidationRules = allInvalidationRules
         };
 
         return config;
@@ -154,5 +203,150 @@ public class AthenaCacheActionFilter(ILogger<AthenaCacheActionFilter> logger) : 
         attributes.AddRange(controllerAttributes);
 
         return attributes;
+    }
+
+    /// <summary>
+    /// Convention 기반 테이블명 추론과 명시적 선언을 병합
+    /// </summary>
+    private static List<TableInvalidationRule> MergeInvalidationRules(
+        ActionExecutingContext context, 
+        IEnumerable<CacheInvalidateOnAttribute> explicitAttributes, 
+        string controllerName)
+    {
+        var rules = new List<TableInvalidationRule>();
+
+        // 1. 명시적 선언 추가 (최우선)
+        rules.AddRange(explicitAttributes.Select(attr => new TableInvalidationRule
+        {
+            TableName = attr.TableName,
+            InvalidationType = attr.InvalidationType,
+            Pattern = attr.Pattern,
+            RelatedTables = attr.RelatedTables,
+            MaxDepth = attr.MaxDepth
+        }));
+
+        // 2. Convention 기반 추론 추가
+        var conventionOptions = context.HttpContext.RequestServices.GetService<AthenaCacheOptions>()?.Convention;
+        if (conventionOptions?.Enabled == true && !IsConventionDisabled(context, controllerName, conventionOptions))
+        {
+            var inferredTableNames = InferTableNamesFromController(controllerName, conventionOptions);
+            
+            foreach (var tableName in inferredTableNames)
+            {
+                // 이미 명시적으로 선언된 테이블은 중복 추가하지 않음
+                if (!rules.Any(r => r.TableName.Equals(tableName, StringComparison.OrdinalIgnoreCase)))
+                {
+                    rules.Add(new TableInvalidationRule
+                    {
+                        TableName = tableName,
+                        InvalidationType = InvalidationType.All,
+                        Pattern = null,
+                        RelatedTables = [],
+                        MaxDepth = -1
+                    });
+                }
+            }
+        }
+
+        return rules;
+    }
+
+    /// <summary>
+    /// 컨트롤러명에서 테이블명 추론
+    /// </summary>
+    private static string[] InferTableNamesFromController(string controllerName, ConventionOptions conventionOptions)
+    {
+        // 1. 설정 기반 매핑 확인 (최우선)
+        if (conventionOptions.ControllerTableMappings.TryGetValue(controllerName, out var mappedTables))
+        {
+            return mappedTables;
+        }
+
+        // 2. 커스텀 다중 테이블 추론 함수 사용
+        if (conventionOptions.CustomMultiTableInferrer != null)
+        {
+            return conventionOptions.CustomMultiTableInferrer(controllerName);
+        }
+
+        // 3. 기본 단일 테이블 추론
+        var baseTableName = ExtractBaseTableName(controllerName, conventionOptions);
+        return [baseTableName];
+    }
+
+    /// <summary>
+    /// 컨트롤러명에서 기본 테이블명 추출
+    /// </summary>
+    private static string ExtractBaseTableName(string controllerName, ConventionOptions conventionOptions)
+    {
+        // "Controller" 접미사 제거
+        var baseName = controllerName.EndsWith("Controller", StringComparison.OrdinalIgnoreCase)
+            ? controllerName[..^10]  // "Controller" 길이 = 10
+            : controllerName;
+
+        // 커스텀 단일 변환 함수 사용
+        if (conventionOptions.CustomPluralizer != null)
+        {
+            return conventionOptions.CustomPluralizer(baseName);
+        }
+
+        // 기본 동작: 복수형 변환 여부에 따라 처리
+        if (conventionOptions.UsePluralizer)
+        {
+            // 간단한 복수형 변환 (향후 Humanizer 라이브러리 연동 가능)
+            return ConvertToPlural(baseName);
+        }
+
+        return baseName;
+    }
+
+    /// <summary>
+    /// 간단한 복수형 변환 (기본 구현)
+    /// </summary>
+    private static string ConvertToPlural(string singular)
+    {
+        // 이미 복수형인지 확인 (간단한 휴리스틱)
+        if (singular.EndsWith("s", StringComparison.OrdinalIgnoreCase) ||
+            singular.EndsWith("es", StringComparison.OrdinalIgnoreCase))
+        {
+            return singular;
+        }
+
+        // 기본 복수형 규칙
+        if (singular.EndsWith("y", StringComparison.OrdinalIgnoreCase))
+        {
+            return singular[..^1] + "ies";
+        }
+        
+        if (singular.EndsWith("s", StringComparison.OrdinalIgnoreCase) ||
+            singular.EndsWith("sh", StringComparison.OrdinalIgnoreCase) ||
+            singular.EndsWith("ch", StringComparison.OrdinalIgnoreCase) ||
+            singular.EndsWith("x", StringComparison.OrdinalIgnoreCase) ||
+            singular.EndsWith("z", StringComparison.OrdinalIgnoreCase))
+        {
+            return singular + "es";
+        }
+
+        return singular + "s";
+    }
+
+    /// <summary>
+    /// Convention 기반 추론이 비활성화되어 있는지 확인
+    /// </summary>
+    private static bool IsConventionDisabled(ActionExecutingContext context, string controllerName, ConventionOptions conventionOptions)
+    {
+        // 1. NoConventionInvalidationAttribute 체크 (액션 레벨 우선)
+        var noConventionAttribute = GetAttribute<NoConventionInvalidationAttribute>(context);
+        if (noConventionAttribute != null)
+        {
+            return true;
+        }
+
+        // 2. 전역 설정에서 제외된 컨트롤러 체크
+        if (conventionOptions.ExcludedControllers.Contains(controllerName))
+        {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/Athena.Cache.Core/Filters/AthenaCacheActionFilter.cs
+++ b/Athena.Cache.Core/Filters/AthenaCacheActionFilter.cs
@@ -1,6 +1,7 @@
 ﻿using Athena.Cache.Core.Abstractions;
 using Athena.Cache.Core.Attributes;
 using Athena.Cache.Core.Configuration;
+using Athena.Cache.Core.Enums;
 using Athena.Cache.Core.Models;
 using Microsoft.AspNetCore.Mvc.Filters;
 

--- a/Athena.Cache.Core/Implementations/DefaultCacheKeyGenerator.cs
+++ b/Athena.Cache.Core/Implementations/DefaultCacheKeyGenerator.cs
@@ -10,22 +10,17 @@ namespace Athena.Cache.Core.Implementations;
 /// <summary>
 /// 기본 캐시 키 생성기 구현 (키 캐싱 포함)
 /// </summary>
-public class DefaultCacheKeyGenerator : ICacheKeyGenerator
+public class DefaultCacheKeyGenerator(AthenaCacheOptions options) : ICacheKeyGenerator
 {
-    private readonly AthenaCacheOptions options;
-    
-    public DefaultCacheKeyGenerator(AthenaCacheOptions options)
-    {
-        this.options = options;
-        
-        // ConcurrentDictionary 최적화: 동시성 수준 설정
-        _keyCache = new ConcurrentDictionary<string, string>(
-            concurrencyLevel: Environment.ProcessorCount * 2, // CPU 코어 수의 2배
-            capacity: MaxCacheSize // 초기 용량 설정
-        );
-    }
+    // ConcurrentDictionary 최적화: 동시성 수준 설정
+    // CPU 코어 수의 2배
+    // 초기 용량 설정
+
     // LRU 캐시로 자주 사용되는 키 저장 (메모리 효율적)
-    private readonly ConcurrentDictionary<string, string> _keyCache;
+    private readonly ConcurrentDictionary<string, string> _keyCache = new(
+        concurrencyLevel: Environment.ProcessorCount * 2, // CPU 코어 수의 2배
+        capacity: MaxCacheSize // 초기 용량 설정
+    );
     private const int MaxCacheSize = 1000; // 최대 캐시 크기
     private long _cacheCount = 0; // 캐시 아이템 수 추적 (Interlocked로 접근)
     /// <summary>

--- a/Athena.Cache.Core/Implementations/DefaultCacheKeyGenerator.cs
+++ b/Athena.Cache.Core/Implementations/DefaultCacheKeyGenerator.cs
@@ -1,23 +1,49 @@
 ﻿using Athena.Cache.Core.Abstractions;
 using Athena.Cache.Core.Configuration;
-using System.Security.Cryptography;
+using System.Collections.Concurrent;
+using System.IO.Hashing;
 using System.Text;
 using System.Text.Json;
 
 namespace Athena.Cache.Core.Implementations;
 
 /// <summary>
-/// 기본 캐시 키 생성기 구현
+/// 기본 캐시 키 생성기 구현 (키 캐싱 포함)
 /// </summary>
-public class DefaultCacheKeyGenerator(AthenaCacheOptions options) : ICacheKeyGenerator
+public class DefaultCacheKeyGenerator : ICacheKeyGenerator
 {
+    private readonly AthenaCacheOptions options;
+    
+    public DefaultCacheKeyGenerator(AthenaCacheOptions options)
+    {
+        this.options = options;
+        
+        // ConcurrentDictionary 최적화: 동시성 수준 설정
+        _keyCache = new ConcurrentDictionary<string, string>(
+            concurrencyLevel: Environment.ProcessorCount * 2, // CPU 코어 수의 2배
+            capacity: MaxCacheSize // 초기 용량 설정
+        );
+    }
+    // LRU 캐시로 자주 사용되는 키 저장 (메모리 효율적)
+    private readonly ConcurrentDictionary<string, string> _keyCache;
+    private const int MaxCacheSize = 1000; // 최대 캐시 크기
+    private long _cacheCount = 0; // 캐시 아이템 수 추적 (Interlocked로 접근)
     /// <summary>
-    /// API 요청 기반 캐시 키 생성
+    /// API 요청 기반 캐시 키 생성 (키 캐싱 포함) - 비동기 최적화 버전
     /// {Namespace}_{Version}_{Controller}_{Action}_{ParameterHash}
     /// 예: MyApp_PROD_v1.2_UsersController_GetUsers_ABC123
     /// </summary>
-    public string GenerateKey(string controller, string action, IDictionary<string, object?>? parameters = null)
+    public ValueTask<string> GenerateKeyAsync(string controller, string action, IDictionary<string, object?>? parameters = null)
     {
+        // 캐시 키 조회를 위한 요청 식별자 생성
+        var requestId = $"{controller}:{action}:{GenerateParameterHash(parameters)}";
+        
+        // 키 캐시 확인 (동기적으로 빠르게 처리)
+        if (_keyCache.TryGetValue(requestId, out var cachedKey))
+        {
+            return new ValueTask<string>(cachedKey);
+        }
+
         var keyParts = new List<string>();
 
         // 네임스페이스 추가
@@ -41,14 +67,33 @@ public class DefaultCacheKeyGenerator(AthenaCacheOptions options) : ICacheKeyGen
         // 액션명 추가
         keyParts.Add(action);
 
-        // 파라미터 해시 추가
+        // 파라미터 해시 추가 (이미 계산됨)
         var parameterHash = GenerateParameterHash(parameters);
         if (!string.IsNullOrEmpty(parameterHash))
         {
             keyParts.Add(parameterHash);
         }
 
-        return string.Join(options.KeySeparator, keyParts);
+        var finalKey = string.Join(options.KeySeparator, keyParts);
+        
+        // 키 캐시에 저장 (크기 제한) - Lock-free 최적화
+        if (Interlocked.Read(ref _cacheCount) < MaxCacheSize)
+        {
+            if (_keyCache.TryAdd(requestId, finalKey))
+            {
+                Interlocked.Increment(ref _cacheCount);
+            }
+        }
+
+        return new ValueTask<string>(finalKey);
+    }
+    
+    /// <summary>
+    /// 동기 버전 유지 (하위 호환성)
+    /// </summary>
+    public string GenerateKey(string controller, string action, IDictionary<string, object?>? parameters = null)
+    {
+        return GenerateKeyAsync(controller, action, parameters).GetAwaiter().GetResult();
     }
 
     /// <summary>
@@ -85,7 +130,7 @@ public class DefaultCacheKeyGenerator(AthenaCacheOptions options) : ICacheKeyGen
     /// 1. null/빈 값 제거
     /// 2. 키 알파벳 순 정렬
     /// 3. JSON 직렬화
-    /// 4. SHA256 해싱
+    /// 4. XxHash64 해싱 (고성능)
     /// </summary>
     public string GenerateParameterHash(IDictionary<string, object?>? parameters)
     {
@@ -112,8 +157,8 @@ public class DefaultCacheKeyGenerator(AthenaCacheOptions options) : ICacheKeyGen
             WriteIndented = false
         });
 
-        // SHA256 해싱
-        return ComputeSha256Hash(json);
+        // XxHash64 해싱 (성능 최적화)
+        return ComputeXxHash64(json);
     }
 
     /// <summary>
@@ -148,17 +193,32 @@ public class DefaultCacheKeyGenerator(AthenaCacheOptions options) : ICacheKeyGen
     }
 
     /// <summary>
-    /// SHA256 해시 계산
+    /// XxHash64 해시 계산 (고성능 해시 함수)
     /// </summary>
-    private static string ComputeSha256Hash(string input)
+    private static string ComputeXxHash64(string input)
     {
         var inputBytes = Encoding.UTF8.GetBytes(input);
-        var hashBytes = SHA256.HashData(inputBytes);
+        var hashValue = XxHash64.HashToUInt64(inputBytes);
+        
+        // Base36 인코딩으로 짧고 안전한 문자열 생성
+        return ConvertToBase36(hashValue);
+    }
 
-        // Base64URL 인코딩 (URL 안전한 문자만 사용)
-        return Convert.ToBase64String(hashBytes)
-            .Replace('+', '-')
-            .Replace('/', '_')
-            .TrimEnd('='); // 패딩 제거
+    /// <summary>
+    /// UInt64를 Base36 문자열로 변환 (0-9, a-z 사용)
+    /// </summary>
+    private static string ConvertToBase36(ulong value)
+    {
+        const string chars = "0123456789abcdefghijklmnopqrstuvwxyz";
+        if (value == 0) return "0";
+
+        var result = new StringBuilder();
+        while (value > 0)
+        {
+            result.Insert(0, chars[(int)(value % 36)]);
+            value /= 36;
+        }
+        
+        return result.ToString();
     }
 }

--- a/Athena.Cache.Core/Implementations/DefaultCacheKeyGenerator.cs
+++ b/Athena.Cache.Core/Implementations/DefaultCacheKeyGenerator.cs
@@ -157,8 +157,8 @@ public class DefaultCacheKeyGenerator : ICacheKeyGenerator
             WriteIndented = false
         });
 
-        // XxHash64 해싱 (성능 최적화)
-        return ComputeXxHash64(json);
+        // XxHash3 해싱 (최신 성능 최적화)
+        return ComputeXxHash3(json);
     }
 
     /// <summary>
@@ -193,12 +193,12 @@ public class DefaultCacheKeyGenerator : ICacheKeyGenerator
     }
 
     /// <summary>
-    /// XxHash64 해시 계산 (고성능 해시 함수)
+    /// XxHash3 해시 계산 (최신 고성능 해시 함수)
     /// </summary>
-    private static string ComputeXxHash64(string input)
+    private static string ComputeXxHash3(string input)
     {
         var inputBytes = Encoding.UTF8.GetBytes(input);
-        var hashValue = XxHash64.HashToUInt64(inputBytes);
+        var hashValue = XxHash3.HashToUInt64(inputBytes);
         
         // Base36 인코딩으로 짧고 안전한 문자열 생성
         return ConvertToBase36(hashValue);

--- a/Athena.Cache.Core/Implementations/IntelligentCacheManager.cs
+++ b/Athena.Cache.Core/Implementations/IntelligentCacheManager.cs
@@ -1,0 +1,430 @@
+using Athena.Cache.Core.Abstractions;
+using Athena.Cache.Core.Configuration;
+using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+
+namespace Athena.Cache.Core.Implementations;
+
+/// <summary>
+/// 지능형 캐시 관리 구현체
+/// Hot Key Detection, Adaptive TTL, LRU/LFU 정책 등 고급 캐싱 패턴 제공
+/// </summary>
+public class IntelligentCacheManager : IIntelligentCacheManager, IDisposable
+{
+    private readonly AthenaCacheOptions _options;
+    private readonly ILogger<IntelligentCacheManager> _logger;
+    
+    // Hot Key Detection
+    private readonly ConcurrentDictionary<string, KeyAccessMetrics> _keyMetrics = new();
+    private readonly Timer? _hotKeyDetectionTimer;
+    private volatile bool _isHotKeyDetectionActive = false;
+    
+    // Adaptive TTL
+    private readonly ConcurrentDictionary<string, TtlMetrics> _ttlMetrics = new();
+    
+    // Cache Priority Calculation
+    private readonly TimeSpan _metricRetentionPeriod = TimeSpan.FromHours(24);
+    private readonly int _hotKeyTopCount = 100;
+    private readonly double _hotKeyThreshold = 10.0; // 접근/분 기준
+    
+    private volatile bool _disposed = false;
+
+    public IntelligentCacheManager(
+        AthenaCacheOptions options,
+        ILogger<IntelligentCacheManager> logger)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        // Hot Key Detection 타이머 (1분마다 실행)
+        _hotKeyDetectionTimer = new Timer(ProcessHotKeyDetection, null, Timeout.Infinite, Timeout.Infinite);
+        
+        _logger.LogInformation("IntelligentCacheManager initialized");
+    }
+
+    #region Hot Key Detection
+
+    public async Task StartHotKeyDetectionAsync(CancellationToken cancellationToken = default)
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(IntelligentCacheManager));
+        
+        if (_isHotKeyDetectionActive) return;
+
+        _isHotKeyDetectionActive = true;
+        _hotKeyDetectionTimer?.Change(TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
+        
+        _logger.LogInformation("Hot Key Detection started");
+        await Task.CompletedTask;
+    }
+
+    public async Task StopHotKeyDetectionAsync()
+    {
+        if (_disposed) return;
+        
+        _isHotKeyDetectionActive = false;
+        _hotKeyDetectionTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+        
+        _logger.LogInformation("Hot Key Detection stopped");
+        await Task.CompletedTask;
+    }
+
+    public async Task<IEnumerable<HotKeyInfo>> GetHotKeysAsync(int topCount = 10, CancellationToken cancellationToken = default)
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(IntelligentCacheManager));
+
+        var cutoffTime = DateTime.UtcNow.Subtract(_metricRetentionPeriod);
+        
+        var hotKeys = _keyMetrics
+            .Where(kvp => kvp.Value.LastAccess > cutoffTime)
+            .Select(kvp => new HotKeyInfo
+            {
+                Key = kvp.Key,
+                AccessCount = kvp.Value.AccessCount,
+                AccessRate = CalculateAccessRate(kvp.Value),
+                FirstAccess = kvp.Value.FirstAccess,
+                LastAccess = kvp.Value.LastAccess,
+                AverageInterval = CalculateAverageInterval(kvp.Value),
+                Priority = CalculateKeyPriorityInternal(kvp.Value)
+            })
+            .OrderByDescending(info => info.AccessRate)
+            .Take(Math.Min(topCount, _hotKeyTopCount))
+            .ToList();
+
+        _logger.LogDebug("Retrieved {Count} hot keys", hotKeys.Count);
+        return await Task.FromResult(hotKeys);
+    }
+
+    public async Task RecordCacheAccessAsync(string cacheKey, CacheAccessType accessType, CancellationToken cancellationToken = default)
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(IntelligentCacheManager));
+        if (string.IsNullOrEmpty(cacheKey)) return;
+
+        var metrics = _keyMetrics.AddOrUpdate(cacheKey, 
+            _ => new KeyAccessMetrics
+            {
+                FirstAccess = DateTime.UtcNow,
+                LastAccess = DateTime.UtcNow,
+                AccessCount = 1,
+                AccessHistory = new ConcurrentQueue<DateTime>()
+            },
+            (_, existing) =>
+            {
+                existing.LastAccess = DateTime.UtcNow;
+                existing.AccessCount++;
+                existing.AccessHistory.Enqueue(DateTime.UtcNow);
+                
+                // 최근 1시간 데이터만 유지 (메모리 효율성) - 간단한 방식으로 변경
+                if (existing.AccessHistory.Count > 1000) // 최대 1000개까지만 유지
+                {
+                    var itemsToRemove = existing.AccessHistory.Count - 1000;
+                    for (int i = 0; i < itemsToRemove; i++)
+                    {
+                        existing.AccessHistory.TryDequeue(out DateTime _);
+                    }
+                }
+                
+                return existing;
+            });
+
+        // TTL 메트릭도 업데이트
+        if (accessType == CacheAccessType.Hit || accessType == CacheAccessType.Miss)
+        {
+            UpdateTtlMetrics(cacheKey, accessType);
+        }
+
+        await Task.CompletedTask;
+    }
+
+    #endregion
+
+    #region Adaptive TTL
+
+    public async Task<TimeSpan> CalculateAdaptiveTtlAsync(string cacheKey, CancellationToken cancellationToken = default)
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(IntelligentCacheManager));
+        if (string.IsNullOrEmpty(cacheKey))
+            return TimeSpan.FromMinutes(_options.DefaultExpirationMinutes);
+
+        // 기본 TTL
+        var baseTtl = TimeSpan.FromMinutes(_options.DefaultExpirationMinutes);
+        
+        // 키 메트릭 조회
+        if (!_keyMetrics.TryGetValue(cacheKey, out var keyMetrics))
+            return baseTtl;
+
+        // TTL 메트릭 조회
+        if (!_ttlMetrics.TryGetValue(cacheKey, out var ttlMetrics))
+            return baseTtl;
+
+        // 적응형 TTL 계산 알고리즘
+        var accessRate = CalculateAccessRate(keyMetrics);
+        var hitRate = ttlMetrics.TotalAccess > 0 ? (double)ttlMetrics.HitCount / ttlMetrics.TotalAccess : 0.0;
+        
+        // 가중치 기반 TTL 조정
+        var accessWeight = Math.Min(accessRate / _hotKeyThreshold, 2.0); // 최대 2배
+        var hitRateWeight = Math.Max(hitRate, 0.5); // 최소 50% 가중치
+        
+        var adjustedTtl = TimeSpan.FromTicks((long)(baseTtl.Ticks * accessWeight * hitRateWeight));
+        
+        // 최소/최대 TTL 제한
+        var minTtl = TimeSpan.FromMinutes(5);
+        var maxTtl = TimeSpan.FromHours(24);
+        
+        if (adjustedTtl < minTtl) adjustedTtl = minTtl;
+        if (adjustedTtl > maxTtl) adjustedTtl = maxTtl;
+
+        _logger.LogDebug("Calculated adaptive TTL for {Key}: {TTL} (AccessRate: {AccessRate}, HitRate: {HitRate})",
+            cacheKey, adjustedTtl, accessRate, hitRate);
+
+        return await Task.FromResult(adjustedTtl);
+    }
+
+    #endregion
+
+    #region Cache Priority & Eviction
+
+    public async Task<double> CalculateKeyPriorityAsync(string cacheKey, CancellationToken cancellationToken = default)
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(IntelligentCacheManager));
+        if (string.IsNullOrEmpty(cacheKey)) return 0.0;
+
+        if (_keyMetrics.TryGetValue(cacheKey, out var metrics))
+        {
+            return await Task.FromResult(CalculateKeyPriorityInternal(metrics));
+        }
+
+        return await Task.FromResult(0.0);
+    }
+
+    public async Task EvictCacheByPolicyAsync(CacheEvictionPolicy policy, int maxItems, CancellationToken cancellationToken = default)
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(IntelligentCacheManager));
+
+        var keysToEvict = policy switch
+        {
+            CacheEvictionPolicy.LRU => GetLruKeys(maxItems),
+            CacheEvictionPolicy.LFU => GetLfuKeys(maxItems),
+            CacheEvictionPolicy.TTL => GetExpiredKeys(maxItems),
+            CacheEvictionPolicy.Random => GetRandomKeys(maxItems),
+            CacheEvictionPolicy.FIFO => GetFifoKeys(maxItems),
+            _ => Enumerable.Empty<string>()
+        };
+
+        var evictedCount = 0;
+        foreach (var key in keysToEvict)
+        {
+            _keyMetrics.TryRemove(key, out _);
+            _ttlMetrics.TryRemove(key, out _);
+            evictedCount++;
+        }
+
+        _logger.LogInformation("Evicted {Count} keys using {Policy} policy", evictedCount, policy);
+        await Task.CompletedTask;
+    }
+
+    #endregion
+
+    #region Cache Warming
+
+    public async Task WarmCacheAsync(IEnumerable<string> keys, CancellationToken cancellationToken = default)
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(IntelligentCacheManager));
+
+        var keyList = keys.ToList();
+        if (keyList.Count == 0) return;
+
+        _logger.LogInformation("Starting cache warming for {Count} keys", keyList.Count);
+        
+        // 병렬로 캐시 워밍 실행 (구현은 실제 캐시 제공자에 따라 달라짐)
+        var warmingTasks = keyList.Select(async key =>
+        {
+            try
+            {
+                // 여기서는 메트릭만 초기화 (실제 데이터 로딩은 캐시 제공자가 담당)
+                await RecordCacheAccessAsync(key, CacheAccessType.Set, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to warm cache for key: {Key}", key);
+            }
+        });
+
+        await Task.WhenAll(warmingTasks);
+        _logger.LogInformation("Cache warming completed");
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    private void ProcessHotKeyDetection(object? state)
+    {
+        if (!_isHotKeyDetectionActive || _disposed) return;
+
+        try
+        {
+            var cutoffTime = DateTime.UtcNow.Subtract(_metricRetentionPeriod);
+            var expiredKeys = _keyMetrics
+                .Where(kvp => kvp.Value.LastAccess < cutoffTime)
+                .Select(kvp => kvp.Key)
+                .ToList();
+
+            // 만료된 메트릭 정리
+            foreach (var key in expiredKeys)
+            {
+                _keyMetrics.TryRemove(key, out _);
+                _ttlMetrics.TryRemove(key, out _);
+            }
+
+            // Hot Key 감지 및 로깅
+            var hotKeys = _keyMetrics
+                .Where(kvp => CalculateAccessRate(kvp.Value) >= _hotKeyThreshold)
+                .OrderByDescending(kvp => CalculateAccessRate(kvp.Value))
+                .Take(10)
+                .ToList();
+
+            if (hotKeys.Any())
+            {
+                _logger.LogInformation("Detected {Count} hot keys: {Keys}",
+                    hotKeys.Count,
+                    string.Join(", ", hotKeys.Select(kvp => $"{kvp.Key}({CalculateAccessRate(kvp.Value):F1}/min)")));
+            }
+
+            _logger.LogDebug("Hot key detection completed. Cleaned {ExpiredCount} expired metrics, detected {HotCount} hot keys",
+                expiredKeys.Count, hotKeys.Count);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during hot key detection processing");
+        }
+    }
+
+    private double CalculateAccessRate(KeyAccessMetrics metrics)
+    {
+        var duration = DateTime.UtcNow - metrics.FirstAccess;
+        if (duration.TotalMinutes < 1) return metrics.AccessCount; // 1분 미만이면 총 액세스 수 반환
+        
+        return metrics.AccessCount / duration.TotalMinutes;
+    }
+
+    private TimeSpan CalculateAverageInterval(KeyAccessMetrics metrics)
+    {
+        if (metrics.AccessCount <= 1) return TimeSpan.Zero;
+        
+        var totalDuration = metrics.LastAccess - metrics.FirstAccess;
+        return TimeSpan.FromTicks(totalDuration.Ticks / (metrics.AccessCount - 1));
+    }
+
+    private double CalculateKeyPriorityInternal(KeyAccessMetrics metrics)
+    {
+        var accessRate = CalculateAccessRate(metrics);
+        var recency = (DateTime.UtcNow - metrics.LastAccess).TotalMinutes;
+        var recencyScore = Math.Max(0, 60 - recency) / 60.0; // 1시간 내 접근에 높은 점수
+        
+        return accessRate * 0.7 + recencyScore * 0.3; // 접근 빈도 70%, 최근성 30%
+    }
+
+    private void UpdateTtlMetrics(string cacheKey, CacheAccessType accessType)
+    {
+        _ttlMetrics.AddOrUpdate(cacheKey,
+            _ => new TtlMetrics
+            {
+                HitCount = accessType == CacheAccessType.Hit ? 1 : 0,
+                MissCount = accessType == CacheAccessType.Miss ? 1 : 0,
+                TotalAccess = 1
+            },
+            (_, existing) =>
+            {
+                if (accessType == CacheAccessType.Hit)
+                    existing.HitCount++;
+                else if (accessType == CacheAccessType.Miss)
+                    existing.MissCount++;
+                
+                existing.TotalAccess++;
+                return existing;
+            });
+    }
+
+    private IEnumerable<string> GetLruKeys(int maxItems)
+    {
+        return _keyMetrics
+            .OrderBy(kvp => kvp.Value.LastAccess)
+            .Take(maxItems)
+            .Select(kvp => kvp.Key);
+    }
+
+    private IEnumerable<string> GetLfuKeys(int maxItems)
+    {
+        return _keyMetrics
+            .OrderBy(kvp => kvp.Value.AccessCount)
+            .Take(maxItems)
+            .Select(kvp => kvp.Key);
+    }
+
+    private IEnumerable<string> GetExpiredKeys(int maxItems)
+    {
+        var now = DateTime.UtcNow;
+        return _keyMetrics
+            .Where(kvp => now - kvp.Value.LastAccess > TimeSpan.FromMinutes(_options.DefaultExpirationMinutes))
+            .Take(maxItems)
+            .Select(kvp => kvp.Key);
+    }
+
+    private IEnumerable<string> GetRandomKeys(int maxItems)
+    {
+        var random = new Random();
+        return _keyMetrics.Keys
+            .OrderBy(_ => random.Next())
+            .Take(maxItems);
+    }
+
+    private IEnumerable<string> GetFifoKeys(int maxItems)
+    {
+        return _keyMetrics
+            .OrderBy(kvp => kvp.Value.FirstAccess)
+            .Take(maxItems)
+            .Select(kvp => kvp.Key);
+    }
+
+    #endregion
+
+    #region IDisposable
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+
+        _hotKeyDetectionTimer?.Dispose();
+        _isHotKeyDetectionActive = false;
+        
+        _keyMetrics.Clear();
+        _ttlMetrics.Clear();
+        
+        _disposed = true;
+        _logger.LogInformation("IntelligentCacheManager disposed");
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// 키 접근 메트릭
+/// </summary>
+internal class KeyAccessMetrics
+{
+    public DateTime FirstAccess { get; set; }
+    public DateTime LastAccess { get; set; }
+    public long AccessCount { get; set; }
+    public ConcurrentQueue<DateTime> AccessHistory { get; set; } = new();
+}
+
+/// <summary>
+/// TTL 관련 메트릭
+/// </summary>
+internal class TtlMetrics
+{
+    public long HitCount { get; set; }
+    public long MissCount { get; set; }
+    public long TotalAccess { get; set; }
+}

--- a/Athena.Cache.Core/Implementations/IntelligentCacheManager.cs
+++ b/Athena.Cache.Core/Implementations/IntelligentCacheManager.cs
@@ -1,8 +1,6 @@
 using Athena.Cache.Core.Abstractions;
 using Athena.Cache.Core.Configuration;
-using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
-using System.Diagnostics;
 
 namespace Athena.Cache.Core.Implementations;
 
@@ -208,7 +206,7 @@ public class IntelligentCacheManager : IIntelligentCacheManager, IDisposable
             CacheEvictionPolicy.TTL => GetExpiredKeys(maxItems),
             CacheEvictionPolicy.Random => GetRandomKeys(maxItems),
             CacheEvictionPolicy.FIFO => GetFifoKeys(maxItems),
-            _ => Enumerable.Empty<string>()
+            _ => []
         };
 
         var evictedCount = 0;

--- a/Athena.Cache.Core/Memory/CachedConstants.cs
+++ b/Athena.Cache.Core/Memory/CachedConstants.cs
@@ -1,0 +1,124 @@
+namespace Athena.Cache.Core.Memory;
+
+/// <summary>
+/// 자주 사용되는 상수들을 미리 캐싱하여 메모리 할당 최소화
+/// 문자열 인터닝과 유사한 효과를 제공
+/// </summary>
+public static class CachedConstants
+{
+    // HTTP 메서드들
+    public static readonly string HttpGet = LazyCache.InternString("GET");
+    public static readonly string HttpPost = LazyCache.InternString("POST");
+    public static readonly string HttpPut = LazyCache.InternString("PUT");
+    public static readonly string HttpDelete = LazyCache.InternString("DELETE");
+    public static readonly string HttpPatch = LazyCache.InternString("PATCH");
+    public static readonly string HttpHead = LazyCache.InternString("HEAD");
+    public static readonly string HttpOptions = LazyCache.InternString("OPTIONS");
+    
+    // Content Types
+    public static readonly string ContentTypeJson = LazyCache.InternString("application/json");
+    public static readonly string ContentTypeText = LazyCache.InternString("text/plain");
+    public static readonly string ContentTypeHtml = LazyCache.InternString("text/html");
+    public static readonly string ContentTypeXml = LazyCache.InternString("application/xml");
+    
+    // 캐시 관련 문자열들
+    public static readonly string CacheHit = LazyCache.InternString("HIT");
+    public static readonly string CacheMiss = LazyCache.InternString("MISS");
+    public static readonly string CacheExpired = LazyCache.InternString("EXPIRED");
+    public static readonly string CacheDisabled = LazyCache.InternString("DISABLED");
+    
+    // 우선순위 레벨들
+    public static readonly string PriorityHigh = LazyCache.InternString("high");
+    public static readonly string PriorityMedium = LazyCache.InternString("medium");
+    public static readonly string PriorityLow = LazyCache.InternString("low");
+    public static readonly string PriorityCritical = LazyCache.InternString("critical");
+    
+    // 상태값들
+    public static readonly string StatusPending = LazyCache.InternString("pending");
+    public static readonly string StatusCompleted = LazyCache.InternString("completed");
+    public static readonly string StatusInProgress = LazyCache.InternString("in_progress");
+    public static readonly string StatusFailed = LazyCache.InternString("failed");
+    public static readonly string StatusSuccess = LazyCache.InternString("success");
+    
+    // 메트릭 관련 문자열들
+    public static readonly string MetricGet = LazyCache.InternString("get");
+    public static readonly string MetricSet = LazyCache.InternString("set");
+    public static readonly string MetricHit = LazyCache.InternString("hit");
+    public static readonly string MetricMiss = LazyCache.InternString("miss");
+    public static readonly string MetricMiddleware = LazyCache.InternString("middleware");
+    public static readonly string MetricController = LazyCache.InternString("controller");
+    
+    // 일반적인 문자열들
+    public static readonly string Unknown = LazyCache.InternString("unknown");
+    public static readonly string Default = LazyCache.InternString("default");
+    public static readonly string Empty = LazyCache.InternString("");
+    public static readonly string Separator = LazyCache.InternString(":");
+    public static readonly string KeySeparator = LazyCache.InternString("_");
+    
+    // 컨트롤러 접미사
+    public static readonly string ControllerSuffix = LazyCache.InternString("Controller");
+    
+    // 헤더 이름들
+    public static readonly string HeaderCacheControl = LazyCache.InternString("Cache-Control");
+    public static readonly string HeaderExpires = LazyCache.InternString("Expires");
+    public static readonly string HeaderETag = LazyCache.InternString("ETag");
+    public static readonly string HeaderLastModified = LazyCache.InternString("Last-Modified");
+    public static readonly string HeaderAuthorization = LazyCache.InternString("Authorization");
+    public static readonly string HeaderContentType = LazyCache.InternString("Content-Type");
+    
+    // 자주 사용되는 숫자들 (문자열로)
+    public static readonly string Zero = LazyCache.IntToString(0);
+    public static readonly string One = LazyCache.IntToString(1);
+    public static readonly string Ten = LazyCache.IntToString(10);
+    public static readonly string Hundred = LazyCache.IntToString(100);
+    public static readonly string Thousand = LazyCache.IntToString(1000);
+    
+    // 자주 사용되는 백분율들
+    public static readonly string Percent0 = LazyCache.FormatPercentage(0.0);
+    public static readonly string Percent10 = LazyCache.FormatPercentage(0.1);
+    public static readonly string Percent50 = LazyCache.FormatPercentage(0.5);
+    public static readonly string Percent70 = LazyCache.FormatPercentage(0.7);
+    public static readonly string Percent80 = LazyCache.FormatPercentage(0.8);
+    public static readonly string Percent90 = LazyCache.FormatPercentage(0.9);
+    public static readonly string Percent100 = LazyCache.FormatPercentage(1.0);
+    
+    // 자주 사용되는 바이트 크기들
+    public static readonly string Size0B = LazyCache.FormatByteSize(0);
+    public static readonly string Size1KB = LazyCache.FormatByteSize(1024);
+    public static readonly string Size1MB = LazyCache.FormatByteSize(1024 * 1024);
+    public static readonly string Size1GB = LazyCache.FormatByteSize(1024L * 1024 * 1024);
+    
+    /// <summary>
+    /// 자주 사용되는 백분율 값을 캐시에서 가져오기
+    /// </summary>
+    public static string GetCachedPercentage(double ratio)
+    {
+        return ratio switch
+        {
+            0.0 => Percent0,
+            0.1 => Percent10,
+            0.5 => Percent50,
+            0.7 => Percent70,
+            0.8 => Percent80,
+            0.9 => Percent90,
+            1.0 => Percent100,
+            _ => LazyCache.FormatPercentage(ratio)
+        };
+    }
+    
+    /// <summary>
+    /// 자주 사용되는 정수 값을 캐시에서 가져오기
+    /// </summary>
+    public static string GetCachedInt(int value)
+    {
+        return value switch
+        {
+            0 => Zero,
+            1 => One,
+            10 => Ten,
+            100 => Hundred,
+            1000 => Thousand,
+            _ => LazyCache.IntToString(value)
+        };
+    }
+}

--- a/Athena.Cache.Core/Memory/CollectionPools.cs
+++ b/Athena.Cache.Core/Memory/CollectionPools.cs
@@ -1,0 +1,95 @@
+using Microsoft.Extensions.ObjectPool;
+using System.Collections.Concurrent;
+using System.Text;
+using Athena.Cache.Core.Analytics;
+
+namespace Athena.Cache.Core.Memory;
+
+/// <summary>
+/// 컬렉션 재사용을 위한 ObjectPool 정책들
+/// 메모리 할당을 최소화하여 GC 압박을 줄임
+/// </summary>
+public static class CollectionPools
+{
+    // List<T> 풀들
+    private static readonly ObjectPool<List<OptimizationRecommendation>> _optimizationRecommendationPool;
+    private static readonly ObjectPool<List<string>> _stringPool;
+    
+    // Dictionary 풀들
+    private static readonly ObjectPool<Dictionary<string, object>> _stringObjectDictionaryPool;
+    private static readonly ObjectPool<Dictionary<string, double>> _stringDoublePool;
+    
+    // StringBuilder 풀
+    private static readonly ObjectPool<StringBuilder> _stringBuilderPool;
+
+    static CollectionPools()
+    {
+        var provider = new DefaultObjectPoolProvider();
+        
+        _optimizationRecommendationPool = provider.Create(new ListPoolPolicy<OptimizationRecommendation>());
+        _stringPool = provider.Create(new ListPoolPolicy<string>());
+        
+        _stringObjectDictionaryPool = provider.Create(new DictionaryPoolPolicy<string, object>());
+        _stringDoublePool = provider.Create(new DictionaryPoolPolicy<string, double>());
+        
+        _stringBuilderPool = provider.Create(new StringBuilderPooledObjectPolicy());
+    }
+
+    // List<T> 대여/반환
+    public static List<OptimizationRecommendation> RentOptimizationRecommendationList() => _optimizationRecommendationPool.Get();
+    public static void Return(List<OptimizationRecommendation> list) => _optimizationRecommendationPool.Return(list);
+    
+    public static List<string> RentStringList() => _stringPool.Get();
+    public static void Return(List<string> list) => _stringPool.Return(list);
+    
+
+    // Dictionary 대여/반환
+    public static Dictionary<string, object> RentStringObjectDictionary() => _stringObjectDictionaryPool.Get();
+    public static void Return(Dictionary<string, object> dict) => _stringObjectDictionaryPool.Return(dict);
+    
+    public static Dictionary<string, double> RentStringDoubleDictionary() => _stringDoublePool.Get();
+    public static void Return(Dictionary<string, double> dict) => _stringDoublePool.Return(dict);
+    
+    // StringBuilder 대여/반환
+    public static StringBuilder RentStringBuilder() => _stringBuilderPool.Get();
+    public static void Return(StringBuilder sb) => _stringBuilderPool.Return(sb);
+}
+
+/// <summary>
+/// List<T> 객체 풀 정책
+/// </summary>
+public class ListPoolPolicy<T> : PooledObjectPolicy<List<T>>
+{
+    private const int MaxCapacity = 1024; // 메모리 누수 방지
+
+    public override List<T> Create() => new List<T>();
+
+    public override bool Return(List<T> obj)
+    {
+        if (obj == null || obj.Count > MaxCapacity)
+            return false;
+
+        obj.Clear();
+        return true;
+    }
+}
+
+/// <summary>
+/// Dictionary<TKey, TValue> 객체 풀 정책
+/// </summary>
+public class DictionaryPoolPolicy<TKey, TValue> : PooledObjectPolicy<Dictionary<TKey, TValue>>
+    where TKey : notnull
+{
+    private const int MaxCapacity = 1024; // 메모리 누수 방지
+
+    public override Dictionary<TKey, TValue> Create() => new Dictionary<TKey, TValue>();
+
+    public override bool Return(Dictionary<TKey, TValue> obj)
+    {
+        if (obj == null || obj.Count > MaxCapacity)
+            return false;
+
+        obj.Clear();
+        return true;
+    }
+}

--- a/Athena.Cache.Core/Memory/HighPerformanceStringPool.cs
+++ b/Athena.Cache.Core/Memory/HighPerformanceStringPool.cs
@@ -1,0 +1,251 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Athena.Cache.Core.Memory;
+
+/// <summary>
+/// 고성능 문자열 풀링 시스템
+/// 문자열 할당을 최소화하고 재사용성을 극대화
+/// </summary>
+public static class HighPerformanceStringPool
+{
+    // 길이별 문자열 풀 (더 효율적인 관리)
+    private static readonly ConcurrentDictionary<int, ConcurrentQueue<StringBuilder>> _stringBuilderPools = new();
+    private static readonly ConcurrentDictionary<string, WeakReference<string>> _internPool = new();
+    
+    // 자주 사용되는 문자열 템플릿들
+    private static readonly ConcurrentDictionary<string, string> _templateCache = new();
+    
+    private const int MaxPoolSize = 100;
+    private const int MaxStringLength = 4096;
+    private const int MaxInternPoolSize = 1000;
+    
+    /// <summary>
+    /// StringBuilder를 풀에서 대여 (길이별로 최적화)
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static StringBuilder RentStringBuilder(int capacity = 256)
+    {
+        capacity = Math.Min(capacity, MaxStringLength);
+        var pool = _stringBuilderPools.GetOrAdd(capacity, _ => new ConcurrentQueue<StringBuilder>());
+        
+        if (pool.TryDequeue(out var sb))
+        {
+            sb.Clear();
+            return sb;
+        }
+        
+        return new StringBuilder(capacity);
+    }
+    
+    /// <summary>
+    /// StringBuilder를 풀에 반환
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ReturnStringBuilder(StringBuilder sb, int originalCapacity = 256)
+    {
+        if (sb == null || sb.Capacity > MaxStringLength) return;
+        
+        originalCapacity = Math.Min(originalCapacity, MaxStringLength);
+        var pool = _stringBuilderPools.GetOrAdd(originalCapacity, _ => new ConcurrentQueue<StringBuilder>());
+        
+        // 풀 크기 제한
+        if (GetPoolSize(pool) < MaxPoolSize)
+        {
+            sb.Clear();
+            pool.Enqueue(sb);
+        }
+    }
+    
+    /// <summary>
+    /// 약한 참조 기반 문자열 인터닝 (메모리 누수 방지)
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static string InternWeakly(string str)
+    {
+        if (string.IsNullOrEmpty(str) || str.Length > 200) 
+            return str; // 너무 긴 문자열은 인터닝하지 않음
+        
+        if (_internPool.TryGetValue(str, out var weakRef) && 
+            weakRef.TryGetTarget(out var cachedStr))
+        {
+            return cachedStr;
+        }
+        
+        // 풀 크기 제한
+        if (_internPool.Count >= MaxInternPoolSize)
+        {
+            CleanupInternPool();
+        }
+        
+        _internPool[str] = new WeakReference<string>(str);
+        return str;
+    }
+    
+    /// <summary>
+    /// 템플릿 기반 문자열 생성 (포맷 문자열 캐싱)
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static string FormatWithTemplate(string template, params object[] args)
+    {
+        var cacheKey = $"{template}:{args.Length}";
+        
+        if (!_templateCache.TryGetValue(cacheKey, out var cachedTemplate))
+        {
+            cachedTemplate = template;
+            if (_templateCache.Count < MaxInternPoolSize)
+            {
+                _templateCache[cacheKey] = cachedTemplate;
+            }
+        }
+        
+        return string.Format(cachedTemplate, args);
+    }
+    
+    /// <summary>
+    /// 고성능 문자열 결합 (Span 기반)
+    /// </summary>
+    public static string ConcatenateEfficiently(ReadOnlySpan<string> strings, char separator = '\0')
+    {
+        if (strings.IsEmpty) return string.Empty;
+        if (strings.Length == 1) return strings[0];
+        
+        // 총 길이 계산
+        var totalLength = 0;
+        for (int i = 0; i < strings.Length; i++)
+        {
+            totalLength += strings[i]?.Length ?? 0;
+            if (separator != '\0' && i < strings.Length - 1)
+                totalLength++; // 구분자 길이
+        }
+        
+        // 효율적인 문자열 생성
+        return string.Create(totalLength, (strings: strings.ToArray(), separator), 
+            static (span, state) =>
+            {
+                var position = 0;
+                for (int i = 0; i < state.strings.Length; i++)
+                {
+                    var str = state.strings[i];
+                    if (!string.IsNullOrEmpty(str))
+                    {
+                        str.AsSpan().CopyTo(span.Slice(position));
+                        position += str.Length;
+                    }
+                    
+                    if (state.separator != '\0' && i < state.strings.Length - 1)
+                    {
+                        span[position++] = state.separator;
+                    }
+                }
+            });
+    }
+    
+    /// <summary>
+    /// 메모리 압박 시 인터닝 풀 정리
+    /// </summary>
+    private static void CleanupInternPool()
+    {
+        var keysToRemove = new List<string>();
+        
+        foreach (var kvp in _internPool)
+        {
+            if (!kvp.Value.TryGetTarget(out _))
+            {
+                keysToRemove.Add(kvp.Key);
+            }
+        }
+        
+        foreach (var key in keysToRemove)
+        {
+            _internPool.TryRemove(key, out _);
+        }
+    }
+    
+    /// <summary>
+    /// StringBuilder 풀 크기 확인 (대략적)
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int GetPoolSize(ConcurrentQueue<StringBuilder> pool)
+    {
+        // ConcurrentQueue는 Count 속성이 비싸므로 대략적으로 추정
+        var tempList = new List<StringBuilder>();
+        var count = 0;
+        
+        while (pool.TryDequeue(out var item) && count < MaxPoolSize + 10)
+        {
+            tempList.Add(item);
+            count++;
+        }
+        
+        // 다시 큐에 넣기
+        foreach (var item in tempList)
+        {
+            pool.Enqueue(item);
+        }
+        
+        return count;
+    }
+    
+    /// <summary>
+    /// 풀 통계 정보
+    /// </summary>
+    public static PoolStats GetPoolStats()
+    {
+        return new PoolStats
+        {
+            StringBuilderPoolCount = _stringBuilderPools.Count,
+            InternPoolCount = _internPool.Count,
+            TemplateCacheCount = _templateCache.Count,
+            EstimatedMemoryUsage = EstimateMemoryUsage()
+        };
+    }
+    
+    /// <summary>
+    /// 예상 메모리 사용량 계산
+    /// </summary>
+    private static long EstimateMemoryUsage()
+    {
+        long total = 0;
+        
+        // StringBuilder 풀 메모리
+        total += _stringBuilderPools.Count * 1024; // 대략적 추정
+        
+        // 인터닝 풀 메모리  
+        total += _internPool.Count * 100; // 평균 문자열 길이 추정
+        
+        // 템플릿 캐시 메모리
+        total += _templateCache.Count * 50; // 평균 템플릿 길이 추정
+        
+        return total;
+    }
+    
+    /// <summary>
+    /// 전체 풀 정리 (메모리 압박 시 사용)
+    /// </summary>
+    public static void ClearAllPools()
+    {
+        _stringBuilderPools.Clear();
+        _internPool.Clear();
+        _templateCache.Clear();
+    }
+}
+
+/// <summary>
+/// 문자열 풀 통계 정보
+/// </summary>
+public readonly struct PoolStats
+{
+    public int StringBuilderPoolCount { get; init; }
+    public int InternPoolCount { get; init; }
+    public int TemplateCacheCount { get; init; }
+    public long EstimatedMemoryUsage { get; init; }
+    
+    public override string ToString()
+    {
+        return $"StringPool Stats - StringBuilder: {StringBuilderPoolCount}, " +
+               $"Intern: {InternPoolCount}, Template: {TemplateCacheCount}, " +
+               $"Memory: {LazyCache.FormatByteSize(EstimatedMemoryUsage)}";
+    }
+}

--- a/Athena.Cache.Core/Memory/LazyCache.cs
+++ b/Athena.Cache.Core/Memory/LazyCache.cs
@@ -1,0 +1,222 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+
+namespace Athena.Cache.Core.Memory;
+
+/// <summary>
+/// 지연 초기화 및 결과 캐싱을 위한 고성능 유틸리티
+/// 반복적으로 계산되는 값들의 메모리 할당을 제거
+/// </summary>
+public static class LazyCache
+{
+    // 문자열 상수 캐싱 (자주 사용되는 문자열들)
+    private static readonly ConcurrentDictionary<string, string> _stringCache = new();
+    
+    // 숫자 → 문자열 변환 캐싱 (자주 사용되는 숫자들)
+    private static readonly ConcurrentDictionary<int, string> _intStringCache = new();
+    private static readonly ConcurrentDictionary<long, string> _longStringCache = new();
+    
+    // 백분율 포맷 캐싱 (자주 사용되는 비율들)
+    private static readonly ConcurrentDictionary<double, string> _percentageCache = new();
+    
+    // 바이트 크기 포맷 캐싱
+    private static readonly ConcurrentDictionary<long, string> _byteSizeCache = new();
+    
+    // 캐시 크기 제한 (메모리 누수 방지)
+    private const int MaxCacheSize = 1000;
+    
+    static LazyCache()
+    {
+        // 자주 사용되는 값들 미리 캐싱
+        PrePopulateCommonValues();
+    }
+    
+    /// <summary>
+    /// 자주 사용되는 값들을 미리 캐싱하여 초기 성능 향상
+    /// </summary>
+    private static void PrePopulateCommonValues()
+    {
+        // 자주 사용되는 정수들 (0-100)
+        for (int i = 0; i <= 100; i++)
+        {
+            _intStringCache[i] = i.ToString();
+        }
+        
+        // 자주 사용되는 백분율들 (0%, 10%, 20%, ..., 100%)
+        for (int i = 0; i <= 100; i += 10)
+        {
+            var ratio = i / 100.0;
+            _percentageCache[ratio] = MemoryUtils.FormatPercentage(ratio);
+        }
+        
+        // 자주 사용되는 바이트 크기들
+        var commonSizes = new long[] 
+        { 
+            0, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288,
+            1024 * 1024, 2 * 1024 * 1024, 4 * 1024 * 1024, 8 * 1024 * 1024,
+            16 * 1024 * 1024, 32 * 1024 * 1024, 64 * 1024 * 1024, 128 * 1024 * 1024,
+            256 * 1024 * 1024, 512 * 1024 * 1024, 1024 * 1024 * 1024L
+        };
+        
+        foreach (var size in commonSizes)
+        {
+            _byteSizeCache[size] = MemoryUtils.FormatByteSize(size);
+        }
+        
+        // 자주 사용되는 문자열들
+        var commonStrings = new[]
+        {
+            "unknown", "pending", "completed", "in_progress", "failed", "success",
+            "high", "medium", "low", "critical", "GET", "POST", "PUT", "DELETE",
+            "application/json", "text/plain", "text/html", "HIT", "MISS",
+            "cache_get", "cache_set", "cache_hit", "cache_miss", "middleware"
+        };
+        
+        foreach (var str in commonStrings)
+        {
+            _stringCache[str] = str; // 인터닝 효과
+        }
+    }
+    
+    /// <summary>
+    /// 정수를 문자열로 변환 (캐싱됨)
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static string IntToString(int value)
+    {
+        if (_intStringCache.TryGetValue(value, out var cached))
+            return cached;
+            
+        if (_intStringCache.Count >= MaxCacheSize)
+            return MemoryUtils.IntToString(value); // 캐시 없이 직접 변환
+            
+        var result = MemoryUtils.IntToString(value);
+        _intStringCache.TryAdd(value, result);
+        return result;
+    }
+    
+    /// <summary>
+    /// Long을 문자열로 변환 (캐싱됨)
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static string LongToString(long value)
+    {
+        if (_longStringCache.TryGetValue(value, out var cached))
+            return cached;
+            
+        if (_longStringCache.Count >= MaxCacheSize)
+            return MemoryUtils.LongToString(value);
+            
+        var result = MemoryUtils.LongToString(value);
+        _longStringCache.TryAdd(value, result);
+        return result;
+    }
+    
+    /// <summary>
+    /// 백분율 포맷팅 (캐싱됨)
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static string FormatPercentage(double ratio, int decimalPlaces = 1)
+    {
+        // 소수점 1자리까지만 캐싱 (메모리 효율성)
+        if (decimalPlaces == 1 && _percentageCache.TryGetValue(ratio, out var cached))
+            return cached;
+            
+        var result = MemoryUtils.FormatPercentage(ratio, decimalPlaces);
+        
+        if (decimalPlaces == 1 && _percentageCache.Count < MaxCacheSize)
+            _percentageCache.TryAdd(ratio, result);
+            
+        return result;
+    }
+    
+    /// <summary>
+    /// 바이트 크기 포맷팅 (캐싱됨)
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static string FormatByteSize(long bytes)
+    {
+        if (_byteSizeCache.TryGetValue(bytes, out var cached))
+            return cached;
+            
+        if (_byteSizeCache.Count >= MaxCacheSize)
+            return MemoryUtils.FormatByteSize(bytes);
+            
+        var result = MemoryUtils.FormatByteSize(bytes);
+        _byteSizeCache.TryAdd(bytes, result);
+        return result;
+    }
+    
+    /// <summary>
+    /// 문자열 인터닝 (자주 사용되는 문자열 캐싱)
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static string InternString(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return value;
+            
+        if (_stringCache.TryGetValue(value, out var cached))
+            return cached;
+            
+        if (_stringCache.Count >= MaxCacheSize)
+            return value;
+            
+        _stringCache.TryAdd(value, value);
+        return value;
+    }
+    
+    /// <summary>
+    /// 캐시 통계 정보
+    /// </summary>
+    public static CacheStats GetCacheStats()
+    {
+        return new CacheStats
+        {
+            StringCacheSize = _stringCache.Count,
+            IntCacheSize = _intStringCache.Count,
+            LongCacheSize = _longStringCache.Count,
+            PercentageCacheSize = _percentageCache.Count,
+            ByteSizeCacheSize = _byteSizeCache.Count,
+            TotalCacheSize = _stringCache.Count + _intStringCache.Count + 
+                           _longStringCache.Count + _percentageCache.Count + 
+                           _byteSizeCache.Count
+        };
+    }
+    
+    /// <summary>
+    /// 캐시 정리 (메모리 압박 시 사용)
+    /// </summary>
+    public static void ClearCaches()
+    {
+        _stringCache.Clear();
+        _intStringCache.Clear();
+        _longStringCache.Clear();
+        _percentageCache.Clear();
+        _byteSizeCache.Clear();
+        
+        // 다시 기본값들 채우기
+        PrePopulateCommonValues();
+    }
+}
+
+/// <summary>
+/// 캐시 통계 정보
+/// </summary>
+public readonly struct CacheStats
+{
+    public int StringCacheSize { get; init; }
+    public int IntCacheSize { get; init; }
+    public int LongCacheSize { get; init; }
+    public int PercentageCacheSize { get; init; }
+    public int ByteSizeCacheSize { get; init; }
+    public int TotalCacheSize { get; init; }
+    
+    public override string ToString()
+    {
+        return $"LazyCache Stats - Total: {TotalCacheSize}, " +
+               $"String: {StringCacheSize}, Int: {IntCacheSize}, " +
+               $"Long: {LongCacheSize}, Percentage: {PercentageCacheSize}, " +
+               $"ByteSize: {ByteSizeCacheSize}";
+    }
+}

--- a/Athena.Cache.Core/Memory/MemoryPressureManager.cs
+++ b/Athena.Cache.Core/Memory/MemoryPressureManager.cs
@@ -1,0 +1,341 @@
+using System.Runtime;
+using Microsoft.Extensions.Logging;
+
+namespace Athena.Cache.Core.Memory;
+
+/// <summary>
+/// 메모리 압박 감지 및 자동 정리 관리자
+/// GC 압박을 모니터링하고 필요시 캐시와 풀을 정리
+/// </summary>
+public class MemoryPressureManager : IDisposable
+{
+    private readonly ILogger<MemoryPressureManager> _logger;
+    private readonly Timer _monitorTimer;
+    private readonly object _cleanupLock = new();
+    
+    private long _lastGcTotalMemory;
+    private int _lastGen0Collections;
+    private int _lastGen1Collections;
+    private int _lastGen2Collections;
+    private DateTime _lastCleanupTime = DateTime.MinValue;
+    
+    // 임계값 설정
+    private const long MemoryPressureThreshold = 512 * 1024 * 1024; // 512MB
+    private const double GcFrequencyThreshold = 5.0; // 5초당 GC 횟수
+    private const int MinCleanupIntervalMinutes = 5; // 최소 정리 간격
+    
+    private volatile bool _disposed = false;
+    
+    public MemoryPressureManager(ILogger<MemoryPressureManager> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        
+        // 초기 상태 기록
+        UpdateGcStats();
+        
+        // 30초마다 메모리 상태 체크
+        _monitorTimer = new Timer(CheckMemoryPressure, null, 
+            TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
+        
+        _logger.LogInformation("MemoryPressureManager started");
+    }
+    
+    /// <summary>
+    /// 메모리 압박 상태 체크 및 정리 수행
+    /// </summary>
+    private void CheckMemoryPressure(object? state)
+    {
+        if (_disposed) return;
+        
+        try
+        {
+            var currentMemory = GC.GetTotalMemory(false);
+            var pressureLevel = AnalyzeMemoryPressure(currentMemory);
+            
+            if (pressureLevel > MemoryPressureLevel.Normal)
+            {
+                _logger.LogWarning("Memory pressure detected: {Level}, Current memory: {Memory}", 
+                    pressureLevel, LazyCache.FormatByteSize(currentMemory));
+                
+                PerformCleanup(pressureLevel);
+            }
+            else
+            {
+                _logger.LogDebug("Memory status normal: {Memory}", 
+                    LazyCache.FormatByteSize(currentMemory));
+            }
+            
+            UpdateGcStats();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during memory pressure check");
+        }
+    }
+    
+    /// <summary>
+    /// 메모리 압박 수준 분석
+    /// </summary>
+    private MemoryPressureLevel AnalyzeMemoryPressure(long currentMemory)
+    {
+        var memoryIncrease = currentMemory - _lastGcTotalMemory;
+        var gcStats = GetCurrentGcStats();
+        
+        // 심각한 메모리 압박 (1GB 이상 또는 빈번한 Gen2 GC)
+        if (currentMemory > 1024 * 1024 * 1024 || gcStats.Gen2Frequency > 2.0)
+        {
+            return MemoryPressureLevel.Critical;
+        }
+        
+        // 높은 메모리 압박 (512MB 이상 또는 빈번한 Gen1 GC)
+        if (currentMemory > MemoryPressureThreshold || gcStats.Gen1Frequency > GcFrequencyThreshold)
+        {
+            return MemoryPressureLevel.High;
+        }
+        
+        // 보통 메모리 압박 (빈번한 Gen0 GC या 메모리 증가)
+        if (gcStats.Gen0Frequency > GcFrequencyThreshold * 2 || memoryIncrease > 100 * 1024 * 1024)
+        {
+            return MemoryPressureLevel.Medium;
+        }
+        
+        return MemoryPressureLevel.Normal;
+    }
+    
+    /// <summary>
+    /// 압박 수준에 따른 정리 수행
+    /// </summary>
+    private void PerformCleanup(MemoryPressureLevel level)
+    {
+        lock (_cleanupLock)
+        {
+            // 최소 간격 체크
+            if (DateTime.UtcNow - _lastCleanupTime < TimeSpan.FromMinutes(MinCleanupIntervalMinutes))
+            {
+                return;
+            }
+            
+            _logger.LogInformation("Performing memory cleanup, level: {Level}", level);
+            
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            var initialMemory = GC.GetTotalMemory(false);
+            
+            try
+            {
+                switch (level)
+                {
+                    case MemoryPressureLevel.Medium:
+                        // 가벼운 정리
+                        PerformLightCleanup();
+                        break;
+                        
+                    case MemoryPressureLevel.High:
+                        // 중간 정리
+                        PerformMediumCleanup();
+                        break;
+                        
+                    case MemoryPressureLevel.Critical:
+                        // 강력한 정리
+                        PerformAggressiveCleanup();
+                        break;
+                }
+                
+                var finalMemory = GC.GetTotalMemory(true); // 강제 GC
+                var memoryFreed = initialMemory - finalMemory;
+                
+                _logger.LogInformation("Memory cleanup completed in {Duration}ms, freed: {Memory}", 
+                    stopwatch.ElapsedMilliseconds, LazyCache.FormatByteSize(memoryFreed));
+                
+                _lastCleanupTime = DateTime.UtcNow;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during memory cleanup");
+            }
+            finally
+            {
+                stopwatch.Stop();
+            }
+        }
+    }
+    
+    /// <summary>
+    /// 가벼운 정리 (자주 사용되지 않는 캐시만)
+    /// </summary>
+    private void PerformLightCleanup()
+    {
+        // LazyCache의 일부 정리
+        var cacheStats = LazyCache.GetCacheStats();
+        if (cacheStats.TotalCacheSize > 500)
+        {
+            // 큰 캐시들만 일부 정리
+            // TODO: LazyCache에 부분 정리 메서드 추가 필요
+        }
+        
+        _logger.LogDebug("Light cleanup performed");
+    }
+    
+    /// <summary>
+    /// 중간 수준 정리
+    /// </summary>
+    private void PerformMediumCleanup()
+    {
+        // 문자열 풀 정리
+        HighPerformanceStringPool.ClearAllPools();
+        
+        // LazyCache 일부 정리
+        LazyCache.ClearCaches();
+        
+        // Gen0, Gen1 GC 유도
+        GC.Collect(1, GCCollectionMode.Optimized);
+        
+        _logger.LogDebug("Medium cleanup performed");
+    }
+    
+    /// <summary>
+    /// 공격적 정리 (메모리 위기 상황)
+    /// </summary>
+    private void PerformAggressiveCleanup()
+    {
+        // 모든 캐시와 풀 정리
+        HighPerformanceStringPool.ClearAllPools();
+        LazyCache.ClearCaches();
+        
+        // 컬렉션 풀 정리 (필요시)
+        // CollectionPools.ClearAll(); // TODO: 메서드 추가 필요
+        
+        // 강제 GC 실행 (모든 세대)
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        
+        // Large Object Heap 압축
+        GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;
+        GC.Collect();
+        
+        _logger.LogWarning("Aggressive cleanup performed - all caches cleared and full GC executed");
+    }
+    
+    /// <summary>
+    /// 현재 GC 통계 정보 가져오기
+    /// </summary>
+    private GcStatistics GetCurrentGcStats()
+    {
+        var gen0 = GC.CollectionCount(0);
+        var gen1 = GC.CollectionCount(1);
+        var gen2 = GC.CollectionCount(2);
+        
+        var timeSinceLastCheck = DateTime.UtcNow - _lastCleanupTime;
+        var intervalSeconds = Math.Max(timeSinceLastCheck.TotalSeconds, 1);
+        
+        return new GcStatistics
+        {
+            Gen0Collections = gen0,
+            Gen1Collections = gen1,
+            Gen2Collections = gen2,
+            Gen0Frequency = (gen0 - _lastGen0Collections) / intervalSeconds,
+            Gen1Frequency = (gen1 - _lastGen1Collections) / intervalSeconds,
+            Gen2Frequency = (gen2 - _lastGen2Collections) / intervalSeconds
+        };
+    }
+    
+    /// <summary>
+    /// GC 통계 업데이트
+    /// </summary>
+    private void UpdateGcStats()
+    {
+        _lastGcTotalMemory = GC.GetTotalMemory(false);
+        _lastGen0Collections = GC.CollectionCount(0);
+        _lastGen1Collections = GC.CollectionCount(1);
+        _lastGen2Collections = GC.CollectionCount(2);
+    }
+    
+    /// <summary>
+    /// 현재 메모리 상태 정보 가져오기
+    /// </summary>
+    public MemoryStatus GetMemoryStatus()
+    {
+        var currentMemory = GC.GetTotalMemory(false);
+        var gcStats = GetCurrentGcStats();
+        var pressureLevel = AnalyzeMemoryPressure(currentMemory);
+        
+        return new MemoryStatus
+        {
+            TotalMemoryBytes = currentMemory,
+            PressureLevel = pressureLevel,
+            LastCleanupTime = _lastCleanupTime,
+            GcStatistics = gcStats,
+            CacheStats = LazyCache.GetCacheStats(),
+            StringPoolStats = HighPerformanceStringPool.GetPoolStats()
+        };
+    }
+    
+    /// <summary>
+    /// 수동으로 정리 실행
+    /// </summary>
+    public void ForceCleanup(MemoryPressureLevel level = MemoryPressureLevel.Medium)
+    {
+        _logger.LogInformation("Manual cleanup requested, level: {Level}", level);
+        PerformCleanup(level);
+    }
+    
+    public void Dispose()
+    {
+        if (_disposed) return;
+        
+        _monitorTimer?.Dispose();
+        _disposed = true;
+        
+        _logger.LogInformation("MemoryPressureManager disposed");
+    }
+}
+
+/// <summary>
+/// 메모리 압박 수준
+/// </summary>
+public enum MemoryPressureLevel
+{
+    Normal,
+    Medium,
+    High,
+    Critical
+}
+
+/// <summary>
+/// GC 통계 정보
+/// </summary>
+public readonly struct GcStatistics
+{
+    public int Gen0Collections { get; init; }
+    public int Gen1Collections { get; init; }
+    public int Gen2Collections { get; init; }
+    public double Gen0Frequency { get; init; }
+    public double Gen1Frequency { get; init; }
+    public double Gen2Frequency { get; init; }
+    
+    public override string ToString()
+    {
+        return $"GC Stats - Gen0: {Gen0Collections}({Gen0Frequency:F1}/s), " +
+               $"Gen1: {Gen1Collections}({Gen1Frequency:F1}/s), " +
+               $"Gen2: {Gen2Collections}({Gen2Frequency:F1}/s)";
+    }
+}
+
+/// <summary>
+/// 전체 메모리 상태 정보
+/// </summary>
+public readonly struct MemoryStatus
+{
+    public long TotalMemoryBytes { get; init; }
+    public MemoryPressureLevel PressureLevel { get; init; }
+    public DateTime LastCleanupTime { get; init; }
+    public GcStatistics GcStatistics { get; init; }
+    public CacheStats CacheStats { get; init; }
+    public PoolStats StringPoolStats { get; init; }
+    
+    public override string ToString()
+    {
+        return $"Memory Status - Total: {LazyCache.FormatByteSize(TotalMemoryBytes)}, " +
+               $"Pressure: {PressureLevel}, Last Cleanup: {LastCleanupTime:HH:mm:ss}";
+    }
+}

--- a/Athena.Cache.Core/Memory/MemoryUtils.cs
+++ b/Athena.Cache.Core/Memory/MemoryUtils.cs
@@ -1,0 +1,219 @@
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Athena.Cache.Core.Memory;
+
+/// <summary>
+/// Memory/Span 기반 고성능 유틸리티 메서드들
+/// 제로 allocation을 목표로 하는 메모리 연산 집합
+/// </summary>
+public static class MemoryUtils
+{
+    /// <summary>
+    /// 문자열을 UTF8 바이트로 변환 (Span 기반)
+    /// 작은 문자열은 stackalloc, 큰 문자열은 ArrayPool 사용
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ReadOnlySpan<byte> GetUtf8Bytes(ReadOnlySpan<char> text, Span<byte> buffer, out bool needsReturn, out byte[]? rentedArray)
+    {
+        needsReturn = false;
+        rentedArray = null;
+        
+        var maxByteCount = Encoding.UTF8.GetMaxByteCount(text.Length);
+        
+        if (maxByteCount <= buffer.Length)
+        {
+            // 제공된 버퍼에 맞음 (일반적으로 stackalloc)
+            var byteCount = Encoding.UTF8.GetBytes(text, buffer);
+            return buffer.Slice(0, byteCount);
+        }
+        else
+        {
+            // ArrayPool에서 대여
+            rentedArray = ArrayPool<byte>.Shared.Rent(maxByteCount);
+            needsReturn = true;
+            var byteCount = Encoding.UTF8.GetBytes(text, rentedArray);
+            return rentedArray.AsSpan(0, byteCount);
+        }
+    }
+    
+    /// <summary>
+    /// UTF8 바이트를 문자열로 변환 (zero allocation when possible)
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static string GetStringFromUtf8(ReadOnlySpan<byte> utf8Bytes)
+    {
+        return Encoding.UTF8.GetString(utf8Bytes);
+    }
+    
+    /// <summary>
+    /// 문자열 배열을 구분자로 결합 (Span 기반)
+    /// </summary>
+    public static string JoinStrings(ReadOnlySpan<string> parts, char separator)
+    {
+        if (parts.IsEmpty) return string.Empty;
+        if (parts.Length == 1) return parts[0];
+        
+        // 총 길이 계산
+        var totalLength = 0;
+        for (int i = 0; i < parts.Length; i++)
+        {
+            totalLength += parts[i].Length;
+            if (i < parts.Length - 1) totalLength++; // 구분자
+        }
+        
+        // 결과 버퍼 생성
+        var result = totalLength <= 1024 
+            ? stackalloc char[totalLength] 
+            : new char[totalLength];
+            
+        var position = 0;
+        for (int i = 0; i < parts.Length; i++)
+        {
+            var part = parts[i].AsSpan();
+            part.CopyTo(result.Slice(position));
+            position += part.Length;
+            
+            if (i < parts.Length - 1)
+            {
+                result[position++] = separator;
+            }
+        }
+        
+        return new string(result);
+    }
+    
+    /// <summary>
+    /// 정수를 문자열로 변환 (Span 기반, allocation 없음)
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static string IntToString(int value)
+    {
+        if (value == 0) return "0";
+        
+        var isNegative = value < 0;
+        if (isNegative) value = -value;
+        
+        Span<char> buffer = stackalloc char[11]; // int.MaxValue는 10자리 + 부호
+        var index = buffer.Length;
+        
+        while (value > 0)
+        {
+            buffer[--index] = (char)('0' + (value % 10));
+            value /= 10;
+        }
+        
+        if (isNegative)
+            buffer[--index] = '-';
+            
+        return new string(buffer.Slice(index));
+    }
+    
+    /// <summary>
+    /// Long을 문자열로 변환 (Span 기반)
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static string LongToString(long value)
+    {
+        if (value == 0) return "0";
+        
+        var isNegative = value < 0;
+        if (isNegative) value = -value;
+        
+        Span<char> buffer = stackalloc char[20]; // long.MaxValue는 19자리 + 부호
+        var index = buffer.Length;
+        
+        while (value > 0)
+        {
+            buffer[--index] = (char)('0' + (value % 10));
+            value /= 10;
+        }
+        
+        if (isNegative)
+            buffer[--index] = '-';
+            
+        return new string(buffer.Slice(index));
+    }
+    
+    /// <summary>
+    /// Double을 고정 소수점 문자열로 변환 (Span 기반)
+    /// </summary>
+    public static string DoubleToFixedString(double value, int decimalPlaces = 2)
+    {
+        if (double.IsNaN(value)) return "NaN";
+        if (double.IsPositiveInfinity(value)) return "∞";
+        if (double.IsNegativeInfinity(value)) return "-∞";
+        
+        var isNegative = value < 0;
+        if (isNegative) value = -value;
+        
+        // 소수점 자리수만큼 곱하기
+        var multiplier = Math.Pow(10, decimalPlaces);
+        var intValue = (long)Math.Round(value * multiplier);
+        
+        Span<char> buffer = stackalloc char[32]; // 충분한 버퍼
+        var index = buffer.Length;
+        
+        // 소수 부분
+        for (int i = 0; i < decimalPlaces; i++)
+        {
+            buffer[--index] = (char)('0' + (intValue % 10));
+            intValue /= 10;
+        }
+        
+        if (decimalPlaces > 0)
+            buffer[--index] = '.';
+        
+        // 정수 부분
+        if (intValue == 0)
+        {
+            buffer[--index] = '0';
+        }
+        else
+        {
+            while (intValue > 0)
+            {
+                buffer[--index] = (char)('0' + (intValue % 10));
+                intValue /= 10;
+            }
+        }
+        
+        if (isNegative)
+            buffer[--index] = '-';
+            
+        return new string(buffer.Slice(index));
+    }
+    
+    /// <summary>
+    /// 바이트 크기를 사람이 읽기 쉬운 형태로 변환 (Span 기반)
+    /// </summary>
+    public static string FormatByteSize(long bytes)
+    {
+        if (bytes == 0) return "0 B";
+        
+        ReadOnlySpan<string> suffixes = new[] { "B", "KB", "MB", "GB", "TB" };
+        var suffixIndex = 0;
+        double size = bytes;
+        
+        while (size >= 1024 && suffixIndex < suffixes.Length - 1)
+        {
+            size /= 1024;
+            suffixIndex++;
+        }
+        
+        var sizeStr = DoubleToFixedString(size, suffixIndex == 0 ? 0 : 1);
+        return $"{sizeStr} {suffixes[suffixIndex]}";
+    }
+    
+    /// <summary>
+    /// 백분율을 문자열로 변환 (Span 기반)
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static string FormatPercentage(double ratio, int decimalPlaces = 1)
+    {
+        var percentage = ratio * 100;
+        var percentageStr = DoubleToFixedString(percentage, decimalPlaces);
+        return $"{percentageStr}%";
+    }
+}

--- a/Athena.Cache.Core/Memory/ValueTypeOptimizations.cs
+++ b/Athena.Cache.Core/Memory/ValueTypeOptimizations.cs
@@ -1,0 +1,299 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Numerics;
+
+namespace Athena.Cache.Core.Memory;
+
+/// <summary>
+/// 값 타입 기반 고성능 최적화
+/// 박싱/언박싱을 제거하고 메모리 레이아웃을 최적화
+/// </summary>
+
+/// <summary>
+/// 캐시 메트릭을 위한 값 타입 구조체 (박싱 없음)
+/// </summary>
+[StructLayout(LayoutKind.Sequential, Pack = 8)]
+public readonly struct CacheMetrics
+{
+    public readonly long HitCount;
+    public readonly long MissCount;
+    public readonly long ErrorCount;
+    public readonly long TotalOperations;
+    public readonly double HitRatio;
+    public readonly TimeSpan AverageResponseTime;
+    public readonly long MemoryUsageBytes;
+    
+    public CacheMetrics(long hitCount, long missCount, long errorCount, 
+                       TimeSpan averageResponseTime, long memoryUsageBytes)
+    {
+        HitCount = hitCount;
+        MissCount = missCount;
+        ErrorCount = errorCount;
+        TotalOperations = hitCount + missCount + errorCount;
+        HitRatio = TotalOperations > 0 ? (double)hitCount / TotalOperations : 0.0;
+        AverageResponseTime = averageResponseTime;
+        MemoryUsageBytes = memoryUsageBytes;
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public string GetFormattedHitRatio() => LazyCache.FormatPercentage(HitRatio);
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public string GetFormattedMemoryUsage() => LazyCache.FormatByteSize(MemoryUsageBytes);
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsHealthy() => HitRatio >= 0.7 && ErrorCount < (TotalOperations * 0.01);
+}
+
+/// <summary>
+/// 캐시 키 정보를 위한 값 타입 구조체
+/// </summary>
+[StructLayout(LayoutKind.Sequential, Pack = 4)]
+public readonly struct CacheKeyInfo
+{
+    public readonly int KeyHashCode;
+    public readonly int KeyLength;
+    public readonly DateTime CreatedAt;
+    public readonly DateTime LastAccessedAt;
+    public readonly int AccessCount;
+    
+    public CacheKeyInfo(string key, DateTime createdAt, DateTime lastAccessedAt, int accessCount)
+    {
+        KeyHashCode = key?.GetHashCode() ?? 0;
+        KeyLength = key?.Length ?? 0;
+        CreatedAt = createdAt;
+        LastAccessedAt = lastAccessedAt;
+        AccessCount = accessCount;
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public TimeSpan GetAge() => DateTime.UtcNow - CreatedAt;
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public TimeSpan GetTimeSinceLastAccess() => DateTime.UtcNow - LastAccessedAt;
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsHot() => AccessCount > 10 && GetTimeSinceLastAccess().TotalMinutes < 5;
+}
+
+/// <summary>
+/// 메모리 할당 없는 키-값 쌍 구조체
+/// </summary>
+[StructLayout(LayoutKind.Sequential, Pack = 8)]
+public readonly struct KeyValueMetric<TKey, TValue> 
+    where TKey : unmanaged 
+    where TValue : unmanaged
+{
+    public readonly TKey Key;
+    public readonly TValue Value;
+    public readonly DateTime Timestamp;
+    
+    public KeyValueMetric(TKey key, TValue value)
+    {
+        Key = key;
+        Value = value;
+        Timestamp = DateTime.UtcNow;
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsExpired(TimeSpan expiration) => DateTime.UtcNow - Timestamp > expiration;
+}
+
+/// <summary>
+/// 고성능 통계 계산기 (값 타입 기반)
+/// </summary>
+public static class ValueTypeStatistics
+{
+    /// <summary>
+    /// 배열의 평균을 계산 (제네릭 + 값 타입)
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double CalculateAverage<T>(ReadOnlySpan<T> values) where T : struct, INumber<T>
+    {
+        if (values.IsEmpty) return 0.0;
+        
+        T sum = T.Zero;
+        foreach (var value in values)
+        {
+            sum += value;
+        }
+        
+        return double.CreateChecked(sum) / values.Length;
+    }
+    
+    /// <summary>
+    /// 배열의 최대값을 찾기 (제네릭 + 값 타입)
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static T FindMaximum<T>(ReadOnlySpan<T> values) where T : struct, IComparable<T>
+    {
+        if (values.IsEmpty) return default;
+        
+        var max = values[0];
+        for (int i = 1; i < values.Length; i++)
+        {
+            if (values[i].CompareTo(max) > 0)
+                max = values[i];
+        }
+        
+        return max;
+    }
+    
+    /// <summary>
+    /// 배열의 최소값을 찾기 (제네릭 + 값 타입)
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static T FindMinimum<T>(ReadOnlySpan<T> values) where T : struct, IComparable<T>
+    {
+        if (values.IsEmpty) return default;
+        
+        var min = values[0];
+        for (int i = 1; i < values.Length; i++)
+        {
+            if (values[i].CompareTo(min) < 0)
+                min = values[i];
+        }
+        
+        return min;
+    }
+    
+    /// <summary>
+    /// 백분위수 계산 (메모리 할당 없음)
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double CalculatePercentile<T>(ReadOnlySpan<T> sortedValues, double percentile) 
+        where T : struct, INumber<T>
+    {
+        if (sortedValues.IsEmpty) return 0.0;
+        if (percentile <= 0) return double.CreateChecked(sortedValues[0]);
+        if (percentile >= 1) return double.CreateChecked(sortedValues[^1]);
+        
+        var index = percentile * (sortedValues.Length - 1);
+        var lowerIndex = (int)Math.Floor(index);
+        var upperIndex = (int)Math.Ceiling(index);
+        
+        if (lowerIndex == upperIndex)
+            return double.CreateChecked(sortedValues[lowerIndex]);
+        
+        var lowerValue = double.CreateChecked(sortedValues[lowerIndex]);
+        var upperValue = double.CreateChecked(sortedValues[upperIndex]);
+        var weight = index - lowerIndex;
+        
+        return lowerValue + (upperValue - lowerValue) * weight;
+    }
+}
+
+/// <summary>
+/// 고성능 비트 연산 유틸리티
+/// </summary>
+public static class BitOptimizations
+{
+    /// <summary>
+    /// 빠른 2의 거듭제곱 체크
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsPowerOfTwo(uint value) => value != 0 && (value & (value - 1)) == 0;
+    
+    /// <summary>
+    /// 다음 2의 거듭제곱 찾기 (캐시 크기 최적화용)
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static uint NextPowerOfTwo(uint value)
+    {
+        if (value == 0) return 1;
+        if (IsPowerOfTwo(value)) return value;
+        
+        value--;
+        value |= value >> 1;
+        value |= value >> 2;
+        value |= value >> 4;
+        value |= value >> 8;
+        value |= value >> 16;
+        
+        return value + 1;
+    }
+    
+    /// <summary>
+    /// 빠른 해시 결합 (FNV-like)
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static uint CombineHashes(uint hash1, uint hash2)
+    {
+        return hash1 ^ (hash2 + 0x9e3779b9 + (hash1 << 6) + (hash1 >> 2));
+    }
+    
+    /// <summary>
+    /// 빠른 나머지 계산 (2의 거듭제곱 모듈로용)
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static uint FastModulo(uint value, uint powerOfTwoModulus)
+    {
+        return value & (powerOfTwoModulus - 1);
+    }
+}
+
+/// <summary>
+/// 메모리 정렬 최적화된 버퍼 (안전한 버전)
+/// </summary>
+[StructLayout(LayoutKind.Sequential, Pack = 64)] // 캐시 라인 정렬
+public struct AlignedBuffer
+{
+    private readonly byte[] _buffer;
+    
+    public AlignedBuffer()
+    {
+        _buffer = new byte[4096]; // 4KB 페이지 크기에 맞춤
+    }
+    
+    public Span<byte> AsSpan() => _buffer.AsSpan();
+    
+    public ReadOnlySpan<byte> AsReadOnlySpan() => _buffer.AsSpan();
+    
+    public int Length => _buffer.Length;
+}
+
+/// <summary>
+/// CPU 캐시 친화적인 해시맵 (값 타입 전용)
+/// </summary>
+public struct ValueTypeHashMap<TKey, TValue> 
+    where TKey : unmanaged, IEquatable<TKey>
+    where TValue : unmanaged
+{
+    private KeyValueMetric<TKey, TValue>[] _buckets;
+    private uint _size;
+    private uint _mask;
+    
+    public ValueTypeHashMap(int capacity = 16)
+    {
+        var size = BitOptimizations.NextPowerOfTwo((uint)Math.Max(capacity, 16));
+        _buckets = new KeyValueMetric<TKey, TValue>[size];
+        _size = size;
+        _mask = size - 1;
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryGet(TKey key, out TValue value)
+    {
+        var hash = (uint)key.GetHashCode();
+        var index = BitOptimizations.FastModulo(hash, _size);
+        
+        ref var bucket = ref _buckets[index];
+        if (bucket.Key.Equals(key))
+        {
+            value = bucket.Value;
+            return true;
+        }
+        
+        value = default;
+        return false;
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Set(TKey key, TValue value)
+    {
+        var hash = (uint)key.GetHashCode();
+        var index = BitOptimizations.FastModulo(hash, _size);
+        
+        _buckets[index] = new KeyValueMetric<TKey, TValue>(key, value);
+    }
+}

--- a/Athena.Cache.Core/Middleware/AthenaCacheMiddleware.cs
+++ b/Athena.Cache.Core/Middleware/AthenaCacheMiddleware.cs
@@ -84,7 +84,7 @@ public class AthenaCacheMiddleware(
                     metrics.RecordOperationDuration(cacheGetMeasurement.Elapsed, "get", "middleware");
                     if (result != null && !string.IsNullOrEmpty(result.Content))
                     {
-                        metrics.RecordValueSize(System.Text.Encoding.UTF8.GetByteCount(result.Content), "cached_response");
+                        metrics.RecordValueSize(Encoding.UTF8.GetByteCount(result.Content), "cached_response");
                     }
                     
                     return result;
@@ -316,8 +316,8 @@ public class AthenaCacheMiddleware(
                             
                             // OpenTelemetry 메트릭 기록
                             metrics.RecordOperationDuration(cacheSetMeasurement.Elapsed, "set", "middleware");
-                            metrics.RecordKeySize(System.Text.Encoding.UTF8.GetByteCount(cacheKey), ExtractKeyPattern(cacheKey));
-                            metrics.RecordValueSize(System.Text.Encoding.UTF8.GetByteCount(responseContent), "cached_response");
+                            metrics.RecordKeySize(Encoding.UTF8.GetByteCount(cacheKey), ExtractKeyPattern(cacheKey));
+                            metrics.RecordValueSize(Encoding.UTF8.GetByteCount(responseContent), "cached_response");
                             
                             return Task.CompletedTask;
                         },

--- a/Athena.Cache.Core/Middleware/CachedResponse.cs
+++ b/Athena.Cache.Core/Middleware/CachedResponse.cs
@@ -1,13 +1,55 @@
-﻿namespace Athena.Cache.Core.Middleware;
+﻿using MessagePack;
+
+namespace Athena.Cache.Core.Middleware;
 
 /// <summary>
-/// 캐시된 HTTP 응답
+/// 캐시된 HTTP 응답 (Object Pooling 지원)
 /// </summary>
+[MessagePackObject]
 public class CachedResponse
 {
+    [Key(0)]
     public int StatusCode { get; set; }
+    
+    [Key(1)]
     public string ContentType { get; set; } = string.Empty;
+    
+    [Key(2)]
     public string Content { get; set; } = string.Empty;
+    
+    [Key(3)]
     public Dictionary<string, string> Headers { get; set; } = new();
+    
+    [Key(4)]
     public DateTime CachedAt { get; set; } = DateTime.UtcNow;
+    
+    [Key(5)]
+    public DateTime ExpiresAt { get; set; }
+    
+    /// <summary>
+    /// 객체 풀링을 위한 초기화 메서드
+    /// </summary>
+    public void Reset()
+    {
+        StatusCode = 0;
+        ContentType = string.Empty;
+        Content = string.Empty;
+        Headers?.Clear();
+        CachedAt = default;
+        ExpiresAt = default;
+    }
+    
+    /// <summary>
+    /// 객체 풀링을 위한 설정 메서드
+    /// </summary>
+    public void Initialize(int statusCode, string contentType, string content, 
+                          Dictionary<string, string> headers, DateTime expiresAt)
+    {
+        StatusCode = statusCode;
+        ContentType = contentType;
+        Content = content;
+        Headers = headers ?? new();
+        CachedAt = DateTime.UtcNow;
+        ExpiresAt = expiresAt;
+    }
 }

--- a/Athena.Cache.Core/ObjectPools/CachedResponsePool.cs
+++ b/Athena.Cache.Core/ObjectPools/CachedResponsePool.cs
@@ -1,0 +1,57 @@
+using Athena.Cache.Core.Middleware;
+using Microsoft.Extensions.ObjectPool;
+
+namespace Athena.Cache.Core.ObjectPools;
+
+/// <summary>
+/// CachedResponse 객체 풀링을 위한 정책 클래스
+/// 메모리 할당을 최소화하고 객체 재사용을 통해 GC 압박을 줄임
+/// </summary>
+public class CachedResponsePooledObjectPolicy : PooledObjectPolicy<CachedResponse>
+{
+    public override CachedResponse Create()
+    {
+        return new CachedResponse();
+    }
+
+    public override bool Return(CachedResponse obj)
+    {
+        if (obj == null) return false;
+        
+        // 객체 상태 초기화 (재사용을 위해)
+        obj.StatusCode = 0;
+        obj.ContentType = string.Empty;
+        obj.Content = string.Empty;
+        obj.Headers?.Clear();
+        obj.CachedAt = default;
+        obj.ExpiresAt = default;
+        
+        return true;
+    }
+}
+
+/// <summary>
+/// CachedResponse 전용 객체 풀 관리자
+/// </summary>
+public class CachedResponsePool
+{
+    private readonly ObjectPool<CachedResponse> _pool;
+    
+    public CachedResponsePool(IServiceProvider serviceProvider)
+    {
+        var poolProvider = serviceProvider.GetService<ObjectPoolProvider>() 
+            ?? new DefaultObjectPoolProvider();
+            
+        _pool = poolProvider.Create(new CachedResponsePooledObjectPolicy());
+    }
+    
+    /// <summary>
+    /// 풀에서 CachedResponse 객체 가져오기
+    /// </summary>
+    public CachedResponse Get() => _pool.Get();
+    
+    /// <summary>
+    /// 사용 완료된 객체를 풀에 반환
+    /// </summary>
+    public void Return(CachedResponse response) => _pool.Return(response);
+}

--- a/Athena.Cache.Core/Observability/AthenaCacheMetrics.cs
+++ b/Athena.Cache.Core/Observability/AthenaCacheMetrics.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.Metrics;
 using System.Diagnostics;
+using Athena.Cache.Core.Abstractions;
 
 namespace Athena.Cache.Core.Observability;
 
@@ -258,10 +259,11 @@ public class AthenaCacheMetrics : IDisposable
 }
 
 /// <summary>
-/// 캐시 성능 통계 스냅샷
+/// 캐시 성능 통계 스냅샷 - ICacheMetrics 구현
 /// </summary>
-public class CachePerformanceSnapshot
+public class CachePerformanceSnapshot : ICacheMetrics
 {
+    public DateTime Timestamp { get; init; } = DateTime.UtcNow;
     public long TotalHits { get; init; }
     public long TotalMisses { get; init; }
     public double HitRatio { get; init; }
@@ -271,5 +273,10 @@ public class CachePerformanceSnapshot
     public long ItemCount { get; init; }
     public long HotKeysCount { get; init; }
     public TimeSpan AverageOperationDuration { get; init; }
+    
+    // ICacheMetrics 인터페이스 구현
+    public double AverageResponseTimeMs => AverageOperationDuration.TotalMilliseconds;
+    
+    // 하위 호환성을 위한 속성 유지
     public DateTime SnapshotTime { get; init; } = DateTime.UtcNow;
 }

--- a/Athena.Cache.Core/Observability/AthenaCacheMetrics.cs
+++ b/Athena.Cache.Core/Observability/AthenaCacheMetrics.cs
@@ -1,0 +1,275 @@
+using System.Diagnostics.Metrics;
+using System.Diagnostics;
+
+namespace Athena.Cache.Core.Observability;
+
+/// <summary>
+/// Athena Cache OpenTelemetry 메트릭 정의
+/// Prometheus, Grafana, Azure Monitor 등과 호환
+/// </summary>
+public class AthenaCacheMetrics : IDisposable
+{
+    private readonly Meter _meter;
+    
+    // Counters - 누적 값
+    private readonly Counter<long> _cacheHitsTotal;
+    private readonly Counter<long> _cacheMissesTotal;
+    private readonly Counter<long> _cacheInvalidationsTotal;
+    private readonly Counter<long> _cacheErrorsTotal;
+    
+    // Histograms - 분포 값
+    private readonly Histogram<double> _cacheOperationDuration;
+    private readonly Histogram<long> _cacheKeySizeBytes;
+    private readonly Histogram<long> _cacheValueSizeBytes;
+    
+    // Gauges - 현재 값
+    private readonly ObservableGauge<long> _cacheMemoryUsageBytes;
+    private readonly ObservableGauge<long> _cacheItemCount;
+    private readonly ObservableGauge<double> _cacheHitRatio;
+    private readonly ObservableGauge<long> _hotKeysCount;
+    
+    // UpDownCounters - 증감 값
+    private readonly UpDownCounter<long> _activeCacheConnections;
+    private readonly UpDownCounter<long> _distributedInvalidationMessages;
+
+    // Observable Gauge 콜백들
+    private Func<long>? _memoryUsageGetter;
+    private Func<long>? _itemCountGetter; 
+    private Func<double>? _hitRatioGetter;
+    private Func<long>? _hotKeysCountGetter;
+
+    public AthenaCacheMetrics()
+    {
+        _meter = new Meter("Athena.Cache", "1.0.0");
+        
+        // === Counters ===
+        _cacheHitsTotal = _meter.CreateCounter<long>(
+            name: "athena_cache_hits_total",
+            unit: "count",
+            description: "Total number of cache hits");
+            
+        _cacheMissesTotal = _meter.CreateCounter<long>(
+            name: "athena_cache_misses_total",
+            unit: "count", 
+            description: "Total number of cache misses");
+            
+        _cacheInvalidationsTotal = _meter.CreateCounter<long>(
+            name: "athena_cache_invalidations_total",
+            unit: "count",
+            description: "Total number of cache invalidations");
+            
+        _cacheErrorsTotal = _meter.CreateCounter<long>(
+            name: "athena_cache_errors_total",
+            unit: "count",
+            description: "Total number of cache errors");
+        
+        // === Histograms ===
+        _cacheOperationDuration = _meter.CreateHistogram<double>(
+            name: "athena_cache_operation_duration_seconds",
+            unit: "s",
+            description: "Duration of cache operations");
+            
+        _cacheKeySizeBytes = _meter.CreateHistogram<long>(
+            name: "athena_cache_key_size_bytes",
+            unit: "bytes",
+            description: "Size of cache keys in bytes");
+            
+        _cacheValueSizeBytes = _meter.CreateHistogram<long>(
+            name: "athena_cache_value_size_bytes", 
+            unit: "bytes",
+            description: "Size of cache values in bytes");
+        
+        // === Observable Gauges ===
+        _cacheMemoryUsageBytes = _meter.CreateObservableGauge<long>(
+            name: "athena_cache_memory_usage_bytes",
+            description: "Current memory usage by cache",
+            observeValue: () => _memoryUsageGetter?.Invoke() ?? 0);
+            
+        _cacheItemCount = _meter.CreateObservableGauge<long>(
+            name: "athena_cache_items_count",
+            description: "Current number of items in cache",
+            observeValue: () => _itemCountGetter?.Invoke() ?? 0);
+            
+        _cacheHitRatio = _meter.CreateObservableGauge<double>(
+            name: "athena_cache_hit_ratio",
+            description: "Current cache hit ratio (0.0-1.0)",
+            observeValue: () => _hitRatioGetter?.Invoke() ?? 0.0);
+            
+        _hotKeysCount = _meter.CreateObservableGauge<long>(
+            name: "athena_cache_hot_keys_count",
+            description: "Current number of detected hot keys",
+            observeValue: () => _hotKeysCountGetter?.Invoke() ?? 0);
+        
+        // === UpDown Counters ===
+        _activeCacheConnections = _meter.CreateUpDownCounter<long>(
+            name: "athena_cache_active_connections",
+            unit: "count",
+            description: "Number of active cache connections");
+            
+        _distributedInvalidationMessages = _meter.CreateUpDownCounter<long>(
+            name: "athena_cache_distributed_invalidation_messages",
+            unit: "count",
+            description: "Number of distributed invalidation messages in queue");
+    }
+
+    #region Counter Methods
+    
+    public void RecordCacheHit(string? cacheType = null, string? keyPattern = null)
+    {
+        var tags = CreateTags(cacheType, keyPattern);
+        _cacheHitsTotal.Add(1, tags);
+    }
+    
+    public void RecordCacheMiss(string? cacheType = null, string? keyPattern = null)
+    {
+        var tags = CreateTags(cacheType, keyPattern);
+        _cacheMissesTotal.Add(1, tags);
+    }
+    
+    public void RecordCacheInvalidation(string tableName, string invalidationType = "table")
+    {
+        _cacheInvalidationsTotal.Add(1, 
+            new("table_name", tableName),
+            new("invalidation_type", invalidationType));
+    }
+    
+    public void RecordCacheError(string operation, string errorType, string? errorMessage = null)
+    {
+        _cacheErrorsTotal.Add(1,
+            new("operation", operation),
+            new("error_type", errorType),
+            new("error_message", errorMessage ?? "unknown"));
+    }
+    
+    #endregion
+    
+    #region Histogram Methods
+    
+    public void RecordOperationDuration(TimeSpan duration, string operation, string? cacheType = null)
+    {
+        _cacheOperationDuration.Record(duration.TotalSeconds,
+            new("operation", operation),
+            new("cache_type", cacheType ?? "default"));
+    }
+    
+    public void RecordKeySize(long sizeBytes, string? keyPattern = null)
+    {
+        var tags = new KeyValuePair<string, object?>[] { new("key_pattern", keyPattern ?? "unknown") };
+        _cacheKeySizeBytes.Record(sizeBytes, tags);
+    }
+    
+    public void RecordValueSize(long sizeBytes, string? valueType = null) 
+    {
+        var tags = new KeyValuePair<string, object?>[] { new("value_type", valueType ?? "unknown") };
+        _cacheValueSizeBytes.Record(sizeBytes, tags);
+    }
+    
+    #endregion
+    
+    #region Observable Methods - These are set externally via callbacks
+    
+    public void SetMemoryUsageCallback(Func<long> memoryUsageGetter)
+    {
+        _memoryUsageGetter = memoryUsageGetter;
+    }
+    
+    public void SetItemCountCallback(Func<long> itemCountGetter)
+    {
+        _itemCountGetter = itemCountGetter;
+    }
+    
+    public void SetHitRatioCallback(Func<double> hitRatioGetter)
+    {
+        _hitRatioGetter = hitRatioGetter;
+    }
+    
+    public void SetHotKeysCountCallback(Func<long> hotKeysCountGetter)
+    {
+        _hotKeysCountGetter = hotKeysCountGetter;
+    }
+    
+    #endregion
+    
+    #region UpDown Counter Methods
+    
+    public void IncrementActiveConnections(int delta = 1)
+    {
+        _activeCacheConnections.Add(delta);
+    }
+    
+    public void DecrementActiveConnections(int delta = 1)
+    {
+        _activeCacheConnections.Add(-delta);
+    }
+    
+    public void IncrementDistributedMessages(int delta = 1)
+    {
+        _distributedInvalidationMessages.Add(delta);
+    }
+    
+    public void DecrementDistributedMessages(int delta = 1)
+    {
+        _distributedInvalidationMessages.Add(-delta);
+    }
+    
+    #endregion
+    
+    #region Activity/Tracing Support
+    
+    private static readonly ActivitySource ActivitySource = new("Athena.Cache");
+    
+    public static Activity? StartActivity(string name, ActivityKind kind = ActivityKind.Internal)
+    {
+        return ActivitySource.StartActivity(name, kind);
+    }
+    
+    public static void RecordException(Activity? activity, Exception exception)
+    {
+        activity?.SetStatus(ActivityStatusCode.Error, exception.Message);
+        activity?.SetTag("exception.type", exception.GetType().Name);
+        activity?.SetTag("exception.message", exception.Message);
+        activity?.SetTag("exception.stacktrace", exception.StackTrace);
+    }
+    
+    #endregion
+    
+    #region Helper Methods
+    
+    private static KeyValuePair<string, object?>[] CreateTags(string? cacheType = null, string? keyPattern = null)
+    {
+        var tags = new List<KeyValuePair<string, object?>>();
+        
+        if (!string.IsNullOrEmpty(cacheType))
+            tags.Add(new("cache_type", cacheType));
+            
+        if (!string.IsNullOrEmpty(keyPattern))
+            tags.Add(new("key_pattern", keyPattern));
+            
+        return tags.ToArray();
+    }
+    
+    #endregion
+    
+    public void Dispose()
+    {
+        _meter?.Dispose();
+        ActivitySource?.Dispose();
+    }
+}
+
+/// <summary>
+/// 캐시 성능 통계 스냅샷
+/// </summary>
+public class CachePerformanceSnapshot
+{
+    public long TotalHits { get; init; }
+    public long TotalMisses { get; init; }
+    public double HitRatio { get; init; }
+    public long TotalInvalidations { get; init; }
+    public long TotalErrors { get; init; }
+    public long MemoryUsageBytes { get; init; }
+    public long ItemCount { get; init; }
+    public long HotKeysCount { get; init; }
+    public TimeSpan AverageOperationDuration { get; init; }
+    public DateTime SnapshotTime { get; init; } = DateTime.UtcNow;
+}

--- a/Athena.Cache.Core/Observability/CacheHealthMonitor.cs
+++ b/Athena.Cache.Core/Observability/CacheHealthMonitor.cs
@@ -1,6 +1,5 @@
 using Athena.Cache.Core.Abstractions;
 using Athena.Cache.Core.Configuration;
-using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
 
 namespace Athena.Cache.Core.Observability;
@@ -464,7 +463,7 @@ public class OverallHealthStatus
 {
     public HealthStatus Status { get; init; }
     public DateTime LastChecked { get; init; }
-    public HealthCheckResult[] HealthChecks { get; init; } = Array.Empty<HealthCheckResult>();
+    public HealthCheckResult[] HealthChecks { get; init; } = [];
     public string Summary { get; init; } = string.Empty;
 }
 

--- a/Athena.Cache.Core/Observability/CacheHealthMonitor.cs
+++ b/Athena.Cache.Core/Observability/CacheHealthMonitor.cs
@@ -1,0 +1,488 @@
+using Athena.Cache.Core.Abstractions;
+using Athena.Cache.Core.Configuration;
+using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
+
+namespace Athena.Cache.Core.Observability;
+
+/// <summary>
+/// 캐시 상태 모니터링 및 헬스 체크 관리자
+/// </summary>
+public class CacheHealthMonitor : IDisposable
+{
+    private readonly IAthenaCache _cache;
+    private readonly IIntelligentCacheManager? _intelligentCacheManager;
+    private readonly IDistributedCacheInvalidator? _distributedInvalidator;
+    private readonly AthenaCacheOptions _options;
+    private readonly AthenaCacheMetrics _metrics;
+    private readonly ILogger<CacheHealthMonitor> _logger;
+    
+    private readonly Timer _healthCheckTimer;
+    private readonly ConcurrentDictionary<string, HealthCheckResult> _healthResults = new();
+    private readonly ConcurrentQueue<CachePerformanceSnapshot> _performanceHistory = new();
+    
+    private volatile bool _disposed = false;
+    private long _totalHits = 0;
+    private long _totalMisses = 0;
+    private long _totalInvalidations = 0;
+    private long _totalErrors = 0;
+
+    public CacheHealthMonitor(
+        IAthenaCache cache,
+        AthenaCacheOptions options,
+        AthenaCacheMetrics metrics,
+        ILogger<CacheHealthMonitor> logger,
+        IIntelligentCacheManager? intelligentCacheManager = null,
+        IDistributedCacheInvalidator? distributedInvalidator = null)
+    {
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _metrics = metrics ?? throw new ArgumentNullException(nameof(metrics));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _intelligentCacheManager = intelligentCacheManager;
+        _distributedInvalidator = distributedInvalidator;
+
+        // 메트릭 콜백 설정
+        SetupMetricCallbacks();
+        
+        // 1분마다 헬스 체크 실행
+        _healthCheckTimer = new Timer(PerformHealthChecks, null, TimeSpan.Zero, TimeSpan.FromMinutes(1));
+        
+        _logger.LogInformation("CacheHealthMonitor initialized");
+    }
+
+    #region Health Check Methods
+
+    public async Task<OverallHealthStatus> GetOverallHealthAsync()
+    {
+        var healthChecks = new[]
+        {
+            await CheckCacheConnectivityAsync(),
+            await CheckCachePerformanceAsync(),
+            await CheckMemoryUsageAsync(),
+            await CheckDistributedConnectionAsync(),
+            await CheckIntelligentCacheAsync()
+        };
+
+        var overallStatus = healthChecks.All(h => h.Status == HealthStatus.Healthy) 
+            ? HealthStatus.Healthy
+            : healthChecks.Any(h => h.Status == HealthStatus.Critical)
+                ? HealthStatus.Critical 
+                : HealthStatus.Warning;
+
+        return new OverallHealthStatus
+        {
+            Status = overallStatus,
+            LastChecked = DateTime.UtcNow,
+            HealthChecks = healthChecks,
+            Summary = GenerateHealthSummary(healthChecks)
+        };
+    }
+
+    private async Task<HealthCheckResult> CheckCacheConnectivityAsync()
+    {
+        try
+        {
+            var testKey = $"__health_check_{Guid.NewGuid():N}";
+            var testValue = "health_check_value";
+            
+            using var activity = AthenaCacheMetrics.StartActivity("health_check.connectivity");
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            
+            // 연결 상태 테스트
+            await _cache.SetAsync(testKey, testValue, TimeSpan.FromMinutes(1));
+            var retrievedValue = await _cache.GetAsync<string>(testKey);
+            await _cache.RemoveAsync(testKey);
+            
+            stopwatch.Stop();
+            
+            var isHealthy = testValue.Equals(retrievedValue);
+            var latency = stopwatch.ElapsedMilliseconds;
+            
+            return new HealthCheckResult
+            {
+                Name = "Cache Connectivity",
+                Status = isHealthy && latency < 1000 ? HealthStatus.Healthy 
+                       : latency < 5000 ? HealthStatus.Warning 
+                       : HealthStatus.Critical,
+                Message = $"Connectivity check completed in {latency}ms",
+                Details = new Dictionary<string, object>
+                {
+                    { "latency_ms", latency },
+                    { "connectivity_test_passed", isHealthy }
+                }
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Cache connectivity health check failed");
+            return new HealthCheckResult
+            {
+                Name = "Cache Connectivity",
+                Status = HealthStatus.Critical,
+                Message = $"Connectivity failed: {ex.Message}",
+                Exception = ex
+            };
+        }
+    }
+
+    private async Task<HealthCheckResult> CheckCachePerformanceAsync()
+    {
+        try
+        {
+            var hitRatio = CalculateHitRatio();
+            var avgOperationTime = await MeasureAverageOperationTimeAsync();
+            
+            var status = hitRatio >= 0.8 && avgOperationTime < 50 ? HealthStatus.Healthy
+                       : hitRatio >= 0.6 && avgOperationTime < 100 ? HealthStatus.Warning
+                       : HealthStatus.Critical;
+
+            return new HealthCheckResult
+            {
+                Name = "Cache Performance",
+                Status = status,
+                Message = $"Hit Ratio: {hitRatio:P1}, Avg Operation: {avgOperationTime:F1}ms",
+                Details = new Dictionary<string, object>
+                {
+                    { "hit_ratio", hitRatio },
+                    { "average_operation_ms", avgOperationTime },
+                    { "total_hits", _totalHits },
+                    { "total_misses", _totalMisses }
+                }
+            };
+        }
+        catch (Exception ex)
+        {
+            return new HealthCheckResult
+            {
+                Name = "Cache Performance",
+                Status = HealthStatus.Warning,
+                Message = $"Performance check failed: {ex.Message}",
+                Exception = ex
+            };
+        }
+    }
+
+    private async Task<HealthCheckResult> CheckMemoryUsageAsync()
+    {
+        try
+        {
+            var memoryUsage = GC.GetTotalMemory(false);
+            var maxMemory = GC.GetTotalMemory(true); // Force GC to get more accurate reading
+            
+            // 통계 정보 수집
+            var stats = await _cache.GetStatisticsAsync();
+            
+            var memoryMB = memoryUsage / (1024.0 * 1024.0);
+            var maxMemoryMB = maxMemory / (1024.0 * 1024.0);
+            var memoryUsageRatio = memoryUsage / (double)Math.Max(maxMemory, 1);
+            
+            var status = memoryUsageRatio < 0.8 ? HealthStatus.Healthy
+                       : memoryUsageRatio < 0.9 ? HealthStatus.Warning
+                       : HealthStatus.Critical;
+
+            return new HealthCheckResult
+            {
+                Name = "Memory Usage",
+                Status = status,
+                Message = $"Memory: {memoryMB:F1}MB, Items: {stats?.ItemCount ?? 0}",
+                Details = new Dictionary<string, object>
+                {
+                    { "memory_usage_mb", memoryMB },
+                    { "memory_usage_ratio", memoryUsageRatio },
+                    { "cache_item_count", stats?.ItemCount ?? 0 },
+                    { "last_cleanup", stats?.LastCleanup ?? DateTime.MinValue }
+                }
+            };
+        }
+        catch (Exception ex)
+        {
+            return new HealthCheckResult
+            {
+                Name = "Memory Usage", 
+                Status = HealthStatus.Warning,
+                Message = $"Memory check failed: {ex.Message}",
+                Exception = ex
+            };
+        }
+    }
+
+    private async Task<HealthCheckResult> CheckDistributedConnectionAsync()
+    {
+        if (_distributedInvalidator == null)
+        {
+            return new HealthCheckResult
+            {
+                Name = "Distributed Connection",
+                Status = HealthStatus.Healthy,
+                Message = "Distributed invalidation not configured (optional)"
+            };
+        }
+
+        try
+        {
+            var isConnected = _distributedInvalidator.IsConnected;
+            var instanceId = _distributedInvalidator.InstanceId;
+            
+            return new HealthCheckResult
+            {
+                Name = "Distributed Connection",
+                Status = isConnected ? HealthStatus.Healthy : HealthStatus.Critical,
+                Message = $"Instance {instanceId}: {(isConnected ? "Connected" : "Disconnected")}",
+                Details = new Dictionary<string, object>
+                {
+                    { "is_connected", isConnected },
+                    { "instance_id", instanceId }
+                }
+            };
+        }
+        catch (Exception ex)
+        {
+            return new HealthCheckResult
+            {
+                Name = "Distributed Connection",
+                Status = HealthStatus.Critical,
+                Message = $"Distributed connection check failed: {ex.Message}",
+                Exception = ex
+            };
+        }
+    }
+
+    private async Task<HealthCheckResult> CheckIntelligentCacheAsync()
+    {
+        if (_intelligentCacheManager == null)
+        {
+            return new HealthCheckResult
+            {
+                Name = "Intelligent Cache",
+                Status = HealthStatus.Healthy,
+                Message = "Intelligent caching not configured (optional)"
+            };
+        }
+
+        try
+        {
+            var hotKeys = await _intelligentCacheManager.GetHotKeysAsync(5);
+            var hotKeyCount = hotKeys.Count();
+
+            return new HealthCheckResult
+            {
+                Name = "Intelligent Cache",
+                Status = HealthStatus.Healthy,
+                Message = $"Detected {hotKeyCount} hot keys",
+                Details = new Dictionary<string, object>
+                {
+                    { "hot_keys_count", hotKeyCount },
+                    { "top_hot_keys", hotKeys.Take(3).Select(k => k.Key).ToArray() }
+                }
+            };
+        }
+        catch (Exception ex)
+        {
+            return new HealthCheckResult
+            {
+                Name = "Intelligent Cache",
+                Status = HealthStatus.Warning,
+                Message = $"Intelligent cache check failed: {ex.Message}",
+                Exception = ex
+            };
+        }
+    }
+
+    #endregion
+
+    #region Performance Tracking
+
+    public void RecordCacheHit() 
+    {
+        Interlocked.Increment(ref _totalHits);
+        _metrics.RecordCacheHit();
+    }
+
+    public void RecordCacheMiss() 
+    {
+        Interlocked.Increment(ref _totalMisses);
+        _metrics.RecordCacheMiss();
+    }
+
+    public void RecordInvalidation(string tableName)
+    {
+        Interlocked.Increment(ref _totalInvalidations);
+        _metrics.RecordCacheInvalidation(tableName);
+    }
+
+    public void RecordError(string operation, Exception exception)
+    {
+        Interlocked.Increment(ref _totalErrors);
+        _metrics.RecordCacheError(operation, exception.GetType().Name, exception.Message);
+    }
+
+    public CachePerformanceSnapshot GetCurrentSnapshot()
+    {
+        return new CachePerformanceSnapshot
+        {
+            TotalHits = _totalHits,
+            TotalMisses = _totalMisses,
+            HitRatio = CalculateHitRatio(),
+            TotalInvalidations = _totalInvalidations,
+            TotalErrors = _totalErrors,
+            MemoryUsageBytes = GC.GetTotalMemory(false),
+            ItemCount = 0, // Will be set by callback
+            HotKeysCount = 0, // Will be set by callback
+            AverageOperationDuration = TimeSpan.Zero // Will be calculated
+        };
+    }
+
+    public IEnumerable<CachePerformanceSnapshot> GetPerformanceHistory(int maxItems = 60)
+    {
+        return _performanceHistory.TakeLast(maxItems);
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    private void SetupMetricCallbacks()
+    {
+        _metrics.SetMemoryUsageCallback(() => GC.GetTotalMemory(false));
+        _metrics.SetHitRatioCallback(() => CalculateHitRatio());
+        
+        if (_intelligentCacheManager != null)
+        {
+            _metrics.SetHotKeysCountCallback(() => 
+            {
+                try
+                {
+                    // 동기적으로 실행하되, 실패하면 0 반환
+                    var task = _intelligentCacheManager.GetHotKeysAsync(10);
+                    if (task.IsCompleted)
+                    {
+                        return task.Result.Count();
+                    }
+                    return 0; // 비동기 작업이 완료되지 않으면 0 반환
+                }
+                catch
+                {
+                    return 0;
+                }
+            });
+        }
+    }
+
+    private double CalculateHitRatio()
+    {
+        var total = _totalHits + _totalMisses;
+        return total > 0 ? (double)_totalHits / total : 0.0;
+    }
+
+    private async Task<double> MeasureAverageOperationTimeAsync()
+    {
+        var testKey = $"__perf_test_{Guid.NewGuid():N}";
+        var iterations = 10;
+        var totalTime = 0.0;
+
+        for (int i = 0; i < iterations; i++)
+        {
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            await _cache.SetAsync($"{testKey}_{i}", "test_value", TimeSpan.FromMinutes(1));
+            await _cache.GetAsync<string>($"{testKey}_{i}");
+            await _cache.RemoveAsync($"{testKey}_{i}");
+            stopwatch.Stop();
+            
+            totalTime += stopwatch.ElapsedMilliseconds;
+        }
+
+        return totalTime / iterations;
+    }
+
+    private string GenerateHealthSummary(HealthCheckResult[] healthChecks)
+    {
+        var healthy = healthChecks.Count(h => h.Status == HealthStatus.Healthy);
+        var warning = healthChecks.Count(h => h.Status == HealthStatus.Warning);
+        var critical = healthChecks.Count(h => h.Status == HealthStatus.Critical);
+        
+        return $"{healthy} Healthy, {warning} Warning, {critical} Critical";
+    }
+
+    private void PerformHealthChecks(object? state)
+    {
+        if (_disposed) return;
+
+        Task.Run(async () =>
+        {
+            try
+            {
+                var overallHealth = await GetOverallHealthAsync();
+                
+                // 성능 스냅샷 저장
+                var snapshot = GetCurrentSnapshot();
+                _performanceHistory.Enqueue(snapshot);
+                
+                // 최대 60개 (1시간) 유지
+                while (_performanceHistory.Count > 60)
+                {
+                    _performanceHistory.TryDequeue(out _);
+                }
+
+                if (overallHealth.Status == HealthStatus.Critical)
+                {
+                    _logger.LogError("Critical cache health issues detected: {Summary}", overallHealth.Summary);
+                }
+                else if (overallHealth.Status == HealthStatus.Warning)
+                {
+                    _logger.LogWarning("Cache health warnings detected: {Summary}", overallHealth.Summary);
+                }
+                else
+                {
+                    _logger.LogDebug("Cache health check completed: {Summary}", overallHealth.Summary);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during health check execution");
+            }
+        });
+    }
+
+    #endregion
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+
+        _healthCheckTimer?.Dispose();
+        _metrics?.Dispose();
+        _disposed = true;
+        
+        _logger.LogInformation("CacheHealthMonitor disposed");
+    }
+}
+
+#region Health Check Models
+
+public class OverallHealthStatus
+{
+    public HealthStatus Status { get; init; }
+    public DateTime LastChecked { get; init; }
+    public HealthCheckResult[] HealthChecks { get; init; } = Array.Empty<HealthCheckResult>();
+    public string Summary { get; init; } = string.Empty;
+}
+
+public class HealthCheckResult
+{
+    public string Name { get; init; } = string.Empty;
+    public HealthStatus Status { get; init; }
+    public string Message { get; init; } = string.Empty;
+    public Dictionary<string, object>? Details { get; init; }
+    public Exception? Exception { get; init; }
+    public DateTime CheckedAt { get; init; } = DateTime.UtcNow;
+}
+
+public enum HealthStatus
+{
+    Healthy,
+    Warning, 
+    Critical
+}
+
+#endregion

--- a/Athena.Cache.Core/Resilience/CacheCircuitBreaker.cs
+++ b/Athena.Cache.Core/Resilience/CacheCircuitBreaker.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
 
 namespace Athena.Cache.Core.Resilience;
@@ -407,13 +406,13 @@ public class CircuitBreakerStatistics
     public int FailureCount { get; init; }
     public DateTime LastFailureTime { get; init; }
     public DateTime LastSuccessTime { get; init; }
-    public OperationMetricSnapshot[] OperationMetrics { get; init; } = Array.Empty<OperationMetricSnapshot>();
+    public OperationMetricSnapshot[] OperationMetrics { get; init; } = [];
     public long TotalOperations { get; init; }
     public long TotalFailures { get; init; }
     public TimeSpan AverageResponseTime { get; init; }
 }
 
-public class OperationMetrics
+public class OperationMetrics(string operationName)
 {
     private readonly object _lock = new();
     private long _totalOperations = 0;
@@ -421,13 +420,8 @@ public class OperationMetrics
     private double _totalResponseTimeMs = 0;
     private DateTime _lastAccess = DateTime.UtcNow;
 
-    public string OperationName { get; }
+    public string OperationName { get; } = operationName;
     public DateTime LastAccess => _lastAccess;
-
-    public OperationMetrics(string operationName)
-    {
-        OperationName = operationName;
-    }
 
     public void RecordSuccess(TimeSpan responseTime)
     {

--- a/Athena.Cache.Core/Resilience/CacheCircuitBreaker.cs
+++ b/Athena.Cache.Core/Resilience/CacheCircuitBreaker.cs
@@ -1,0 +1,500 @@
+using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
+
+namespace Athena.Cache.Core.Resilience;
+
+/// <summary>
+/// 캐시 작업을 위한 Circuit Breaker 패턴 구현
+/// 캐시 오류가 임계치를 초과하면 자동으로 캐시를 우회하여 시스템 안정성 보장
+/// </summary>
+public class CacheCircuitBreaker : IDisposable
+{
+    private readonly ILogger<CacheCircuitBreaker> _logger;
+    private readonly CacheCircuitBreakerOptions _options;
+    
+    private volatile CircuitBreakerState _state = CircuitBreakerState.Closed;
+    private volatile int _failureCount = 0;
+    private long _lastFailureTimeTicks = DateTime.MinValue.Ticks;
+    private long _lastSuccessTimeTicks = DateTime.UtcNow.Ticks;
+    
+    private readonly object _stateLock = new();
+    private readonly Timer _healthCheckTimer;
+    private readonly ConcurrentDictionary<string, OperationMetrics> _operationMetrics = new();
+
+    public CircuitBreakerState State => _state;
+    public int FailureCount => _failureCount;
+    public DateTime LastFailureTime => new DateTime(Interlocked.Read(ref _lastFailureTimeTicks));
+    public DateTime LastSuccessTime => new DateTime(Interlocked.Read(ref _lastSuccessTimeTicks));
+    public bool IsOpen => _state == CircuitBreakerState.Open;
+    public bool IsHalfOpen => _state == CircuitBreakerState.HalfOpen;
+    public bool IsClosed => _state == CircuitBreakerState.Closed;
+
+    public event EventHandler<CircuitBreakerStateChangedEventArgs>? StateChanged;
+
+    public CacheCircuitBreaker(
+        CacheCircuitBreakerOptions options,
+        ILogger<CacheCircuitBreaker> logger)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        // 주기적으로 상태 확인 및 정리
+        _healthCheckTimer = new Timer(PerformHealthCheck, null, 
+            _options.HealthCheckInterval, _options.HealthCheckInterval);
+        
+        _logger.LogInformation("CacheCircuitBreaker initialized with threshold: {Threshold}, timeout: {Timeout}",
+            _options.FailureThreshold, _options.Timeout);
+    }
+
+    #region Circuit Breaker Core Logic
+
+    /// <summary>
+    /// 캐시 작업을 Circuit Breaker로 보호하여 실행
+    /// </summary>
+    public async Task<T> ExecuteAsync<T>(
+        string operationName,
+        Func<Task<T>> operation,
+        Func<Task<T>>? fallback = null,
+        CancellationToken cancellationToken = default)
+    {
+        // Circuit이 Open 상태인지 확인
+        if (!CanExecute())
+        {
+            _logger.LogWarning("Circuit breaker is open for operation: {Operation}", operationName);
+            return await ExecuteFallback(operationName, fallback, cancellationToken);
+        }
+
+        var metrics = GetOrCreateOperationMetrics(operationName);
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+        try
+        {
+            var result = await operation().ConfigureAwait(false);
+            stopwatch.Stop();
+            
+            // 성공 기록
+            RecordSuccess(operationName, stopwatch.Elapsed);
+            metrics.RecordSuccess(stopwatch.Elapsed);
+            
+            return result;
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            
+            // 실패 기록
+            RecordFailure(operationName, ex, stopwatch.Elapsed);
+            metrics.RecordFailure(ex, stopwatch.Elapsed);
+            
+            // Fallback 실행
+            if (fallback != null)
+            {
+                _logger.LogWarning(ex, "Cache operation failed, executing fallback for: {Operation}", operationName);
+                return await ExecuteFallback(operationName, fallback, cancellationToken);
+            }
+            
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// 동기 버전의 Circuit Breaker 실행
+    /// </summary>
+    public T Execute<T>(
+        string operationName,
+        Func<T> operation,
+        Func<T>? fallback = null)
+    {
+        if (!CanExecute())
+        {
+            _logger.LogWarning("Circuit breaker is open for operation: {Operation}", operationName);
+            return ExecuteFallbackSync(operationName, fallback);
+        }
+
+        var metrics = GetOrCreateOperationMetrics(operationName);
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+        try
+        {
+            var result = operation();
+            stopwatch.Stop();
+            
+            RecordSuccess(operationName, stopwatch.Elapsed);
+            metrics.RecordSuccess(stopwatch.Elapsed);
+            
+            return result;
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            
+            RecordFailure(operationName, ex, stopwatch.Elapsed);
+            metrics.RecordFailure(ex, stopwatch.Elapsed);
+            
+            if (fallback != null)
+            {
+                _logger.LogWarning(ex, "Cache operation failed, executing fallback for: {Operation}", operationName);
+                return ExecuteFallbackSync(operationName, fallback);
+            }
+            
+            throw;
+        }
+    }
+
+    private bool CanExecute()
+    {
+        switch (_state)
+        {
+            case CircuitBreakerState.Closed:
+                return true;
+            
+            case CircuitBreakerState.Open:
+                // Timeout이 지났는지 확인
+                var lastFailureTime = new DateTime(Interlocked.Read(ref _lastFailureTimeTicks));
+                if (DateTime.UtcNow - lastFailureTime >= _options.Timeout)
+                {
+                    ChangeState(CircuitBreakerState.HalfOpen);
+                    return true;
+                }
+                return false; 
+            
+            case CircuitBreakerState.HalfOpen:
+                return true;
+            
+            default:
+                return false;
+        }
+    }
+
+    #endregion
+
+    #region State Management
+
+    private void RecordSuccess(string operationName, TimeSpan duration)
+    {
+        Interlocked.Exchange(ref _lastSuccessTimeTicks, DateTime.UtcNow.Ticks);
+        
+        lock (_stateLock)
+        {
+            if (_state == CircuitBreakerState.HalfOpen)
+            {
+                // Half-Open에서 성공하면 Closed로 변경
+                _failureCount = 0;
+                ChangeState(CircuitBreakerState.Closed);
+            }
+            else if (_state == CircuitBreakerState.Closed)
+            {
+                // 연속 실패 카운터 리셋
+                if (_failureCount > 0)
+                {
+                    _failureCount = Math.Max(0, _failureCount - 1);
+                }
+            }
+        }
+        
+        _logger.LogDebug("Cache operation succeeded: {Operation} in {Duration}ms", 
+            operationName, duration.TotalMilliseconds);
+    }
+
+    private void RecordFailure(string operationName, Exception exception, TimeSpan duration)
+    {
+        Interlocked.Exchange(ref _lastFailureTimeTicks, DateTime.UtcNow.Ticks);
+        
+        lock (_stateLock)
+        {
+            _failureCount++;
+            
+            if (_state == CircuitBreakerState.HalfOpen)
+            {
+                // Half-Open에서 실패하면 바로 Open으로
+                ChangeState(CircuitBreakerState.Open);
+            }
+            else if (_state == CircuitBreakerState.Closed && _failureCount >= _options.FailureThreshold)
+            {
+                // 실패 임계치 초과 시 Open으로
+                ChangeState(CircuitBreakerState.Open);
+            }
+        }
+        
+        _logger.LogWarning(exception, "Cache operation failed: {Operation} in {Duration}ms (Failure #{Count})", 
+            operationName, duration.TotalMilliseconds, _failureCount);
+    }
+
+    private void ChangeState(CircuitBreakerState newState)
+    {
+        var oldState = _state;
+        _state = newState;
+        
+        _logger.LogInformation("Circuit breaker state changed from {OldState} to {NewState}", oldState, newState);
+        
+        StateChanged?.Invoke(this, new CircuitBreakerStateChangedEventArgs
+        {
+            OldState = oldState,
+            NewState = newState,
+            FailureCount = _failureCount,
+            Timestamp = DateTime.UtcNow
+        });
+    }
+
+    #endregion
+
+    #region Fallback Execution
+
+    private async Task<T> ExecuteFallback<T>(
+        string operationName,
+        Func<Task<T>>? fallback,
+        CancellationToken cancellationToken)
+    {
+        if (fallback == null)
+        {
+            throw new CacheCircuitBreakerOpenException(
+                $"Circuit breaker is open for operation '{operationName}' and no fallback provided");
+        }
+
+        try
+        {
+            var result = await fallback().ConfigureAwait(false); 
+            _logger.LogDebug("Fallback executed successfully for operation: {Operation}", operationName);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Fallback failed for operation: {Operation}", operationName);
+            throw new CacheCircuitBreakerFallbackException(
+                $"Both primary operation and fallback failed for '{operationName}'", ex);
+        }
+    }
+
+    private T ExecuteFallbackSync<T>(string operationName, Func<T>? fallback)
+    {
+        if (fallback == null)
+        {
+            throw new CacheCircuitBreakerOpenException(
+                $"Circuit breaker is open for operation '{operationName}' and no fallback provided");
+        }
+
+        try
+        {
+            var result = fallback();
+            _logger.LogDebug("Fallback executed successfully for operation: {Operation}", operationName);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Fallback failed for operation: {Operation}", operationName);
+            throw new CacheCircuitBreakerFallbackException(
+                $"Both primary operation and fallback failed for '{operationName}'", ex);
+        }
+    }
+
+    #endregion
+
+    #region Metrics and Health Check
+
+    private OperationMetrics GetOrCreateOperationMetrics(string operationName)
+    {
+        return _operationMetrics.GetOrAdd(operationName, _ => new OperationMetrics(operationName));
+    }
+
+    public CircuitBreakerStatistics GetStatistics()
+    {
+        var operationStats = _operationMetrics.Values
+            .Select(m => m.GetSnapshot())
+            .ToArray();
+
+        return new CircuitBreakerStatistics
+        {
+            State = _state,
+            FailureCount = _failureCount,
+            LastFailureTime = new DateTime(Interlocked.Read(ref _lastFailureTimeTicks)),
+            LastSuccessTime = new DateTime(Interlocked.Read(ref _lastSuccessTimeTicks)),
+            OperationMetrics = operationStats,
+            TotalOperations = operationStats.Sum(s => s.TotalOperations),
+            TotalFailures = operationStats.Sum(s => s.FailureCount),
+            AverageResponseTime = operationStats.Any() 
+                ? TimeSpan.FromMilliseconds(operationStats.Average(s => s.AverageResponseTime.TotalMilliseconds))
+                : TimeSpan.Zero
+        };
+    }
+
+    private void PerformHealthCheck(object? state)
+    {
+        try
+        {
+            // 오래된 메트릭 정리
+            var cutoff = DateTime.UtcNow.Subtract(_options.MetricRetentionPeriod);
+            var expiredOperations = _operationMetrics
+                .Where(kvp => kvp.Value.LastAccess < cutoff)
+                .Select(kvp => kvp.Key)
+                .ToList();
+
+            foreach (var operation in expiredOperations)
+            {
+                _operationMetrics.TryRemove(operation, out _);
+            }
+
+            // 자동 복구 체크 (추가 안전장치)
+            if (_state == CircuitBreakerState.Open)
+            {
+                var lastFailureTime = new DateTime(Interlocked.Read(ref _lastFailureTimeTicks));
+                var timeSinceLastFailure = DateTime.UtcNow - lastFailureTime;
+                if (timeSinceLastFailure >= _options.Timeout * 2) // Timeout의 2배가 지나면 강제 Half-Open
+                {
+                    _logger.LogInformation("Auto-recovery triggered: changing to Half-Open state");
+                    ChangeState(CircuitBreakerState.HalfOpen);
+                }
+            }
+
+            _logger.LogDebug("Circuit breaker health check completed. State: {State}, Failures: {Failures}", 
+                _state, _failureCount);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during circuit breaker health check");
+        }
+    }
+
+    #endregion
+
+    public void Dispose()
+    {
+        _healthCheckTimer?.Dispose();
+        _operationMetrics.Clear();
+        _logger.LogInformation("CacheCircuitBreaker disposed");
+    }
+}
+
+#region Configuration and Models
+
+public class CacheCircuitBreakerOptions
+{
+    /// <summary>Circuit을 Open하기 위한 연속 실패 임계치</summary>
+    public int FailureThreshold { get; set; } = 5;
+    
+    /// <summary>Open 상태에서 Half-Open으로 전환하기 위한 대기 시간</summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromMinutes(1);
+    
+    /// <summary>헬스 체크 주기</summary>
+    public TimeSpan HealthCheckInterval { get; set; } = TimeSpan.FromSeconds(30);
+    
+    /// <summary>메트릭 보존 기간</summary>
+    public TimeSpan MetricRetentionPeriod { get; set; } = TimeSpan.FromHours(1);
+}
+
+public enum CircuitBreakerState
+{
+    /// <summary>정상 상태 - 모든 요청 허용</summary>
+    Closed,
+    
+    /// <summary>차단 상태 - 모든 요청 거부</summary>
+    Open,
+    
+    /// <summary>반열림 상태 - 제한적 요청 허용</summary>
+    HalfOpen
+}
+
+public class CircuitBreakerStateChangedEventArgs : EventArgs
+{
+    public CircuitBreakerState OldState { get; init; }
+    public CircuitBreakerState NewState { get; init; }
+    public int FailureCount { get; init; }
+    public DateTime Timestamp { get; init; }
+}
+
+public class CircuitBreakerStatistics
+{
+    public CircuitBreakerState State { get; init; }
+    public int FailureCount { get; init; }
+    public DateTime LastFailureTime { get; init; }
+    public DateTime LastSuccessTime { get; init; }
+    public OperationMetricSnapshot[] OperationMetrics { get; init; } = Array.Empty<OperationMetricSnapshot>();
+    public long TotalOperations { get; init; }
+    public long TotalFailures { get; init; }
+    public TimeSpan AverageResponseTime { get; init; }
+}
+
+public class OperationMetrics
+{
+    private readonly object _lock = new();
+    private long _totalOperations = 0;
+    private long _failureCount = 0;
+    private double _totalResponseTimeMs = 0;
+    private DateTime _lastAccess = DateTime.UtcNow;
+
+    public string OperationName { get; }
+    public DateTime LastAccess => _lastAccess;
+
+    public OperationMetrics(string operationName)
+    {
+        OperationName = operationName;
+    }
+
+    public void RecordSuccess(TimeSpan responseTime)
+    {
+        lock (_lock)
+        {
+            _totalOperations++;
+            _totalResponseTimeMs += responseTime.TotalMilliseconds;
+            _lastAccess = DateTime.UtcNow;
+        }
+    }
+
+    public void RecordFailure(Exception exception, TimeSpan responseTime)
+    {
+        lock (_lock)
+        {
+            _totalOperations++;
+            _failureCount++;
+            _totalResponseTimeMs += responseTime.TotalMilliseconds;
+            _lastAccess = DateTime.UtcNow;
+        }
+    }
+
+    public OperationMetricSnapshot GetSnapshot()
+    {
+        lock (_lock)
+        {
+            return new OperationMetricSnapshot
+            {
+                OperationName = OperationName,
+                TotalOperations = _totalOperations,
+                FailureCount = _failureCount,
+                SuccessCount = _totalOperations - _failureCount,
+                FailureRate = _totalOperations > 0 ? (double)_failureCount / _totalOperations : 0,
+                AverageResponseTime = _totalOperations > 0 
+                    ? TimeSpan.FromMilliseconds(_totalResponseTimeMs / _totalOperations)
+                    : TimeSpan.Zero,
+                LastAccess = _lastAccess
+            };
+        }
+    }
+}
+
+public class OperationMetricSnapshot
+{
+    public string OperationName { get; init; } = string.Empty;
+    public long TotalOperations { get; init; }
+    public long FailureCount { get; init; }
+    public long SuccessCount { get; init; }
+    public double FailureRate { get; init; }
+    public TimeSpan AverageResponseTime { get; init; }
+    public DateTime LastAccess { get; init; }
+}
+
+#endregion
+
+#region Exceptions
+
+public class CacheCircuitBreakerOpenException : Exception
+{
+    public CacheCircuitBreakerOpenException(string message) : base(message) { }
+    public CacheCircuitBreakerOpenException(string message, Exception innerException) : base(message, innerException) { }
+}
+
+public class CacheCircuitBreakerFallbackException : Exception
+{
+    public CacheCircuitBreakerFallbackException(string message) : base(message) { }
+    public CacheCircuitBreakerFallbackException(string message, Exception innerException) : base(message, innerException) { }
+}
+
+#endregion

--- a/Athena.Cache.Monitoring/AlertChannels/ConsoleAlertChannel.cs
+++ b/Athena.Cache.Monitoring/AlertChannels/ConsoleAlertChannel.cs
@@ -1,0 +1,38 @@
+﻿using Athena.Cache.Monitoring.Enums;
+using Athena.Cache.Monitoring.Interfaces;
+using Athena.Cache.Monitoring.Models;
+
+namespace Athena.Cache.Monitoring.AlertChannels;
+
+/// <summary>
+/// 콘솔 알림 채널 (개발용)
+/// </summary>
+public class ConsoleAlertChannel : IAlertChannel
+{
+    public string Name => "Console";
+
+    public Task SendAsync(CacheAlert alert, CancellationToken cancellationToken = default)
+    {
+        var color = alert.Level switch
+        {
+            AlertLevel.Critical => ConsoleColor.Red,
+            AlertLevel.Warning => ConsoleColor.Yellow,
+            AlertLevel.Info => ConsoleColor.Green,
+            _ => ConsoleColor.White
+        };
+
+        var originalColor = Console.ForegroundColor;
+        Console.ForegroundColor = color;
+        Console.WriteLine($"🚨 [{alert.Level}] {alert.Title}");
+        Console.WriteLine($"   {alert.Message}");
+        Console.WriteLine($"   Component: {alert.Component} | Time: {alert.Timestamp:HH:mm:ss}");
+        Console.ForegroundColor = originalColor;
+
+        return Task.CompletedTask;
+    }
+
+    public Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(true);
+    }
+}

--- a/Athena.Cache.Monitoring/AlertChannels/LogAlertChannel.cs
+++ b/Athena.Cache.Monitoring/AlertChannels/LogAlertChannel.cs
@@ -1,0 +1,35 @@
+﻿using Athena.Cache.Monitoring.Enums;
+using Athena.Cache.Monitoring.Interfaces;
+using Athena.Cache.Monitoring.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Athena.Cache.Monitoring.AlertChannels;
+
+/// <summary>
+/// 로그 기반 알림 채널 (기본 제공)
+/// </summary>
+public class LogAlertChannel(ILogger<LogAlertChannel> logger) : IAlertChannel
+{
+    public string Name => "Log";
+
+    public Task SendAsync(CacheAlert alert, CancellationToken cancellationToken = default)
+    {
+        var logLevel = alert.Level switch
+        {
+            AlertLevel.Critical => LogLevel.Error,
+            AlertLevel.Warning => LogLevel.Warning,
+            AlertLevel.Info => LogLevel.Information,
+            _ => LogLevel.Information
+        };
+
+        logger.Log(logLevel, "Cache Alert: [{Level}] {Title} - {Message} (Component: {Component})",
+            alert.Level, alert.Title, alert.Message, alert.Component);
+
+        return Task.CompletedTask;
+    }
+
+    public Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(true);
+    }
+}

--- a/Athena.Cache.Monitoring/Athena.Cache.Monitoring.csproj
+++ b/Athena.Cache.Monitoring/Athena.Cache.Monitoring.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.7" />
+    <PackageReference Include="StackExchange.Redis" Version="2.8.58" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Athena.Cache.Core\Athena.Cache.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Athena.Cache.Monitoring/CacheHealthChecker.cs
+++ b/Athena.Cache.Monitoring/CacheHealthChecker.cs
@@ -1,0 +1,195 @@
+﻿using Athena.Cache.Core.Abstractions;
+using Athena.Cache.Monitoring.Enums;
+using Athena.Cache.Monitoring.Interfaces;
+using Athena.Cache.Monitoring.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Athena.Cache.Monitoring;
+
+/// <summary>
+/// 캐시 상태 확인 서비스
+/// </summary>
+public class CacheHealthChecker(
+    IAthenaCache cache,
+    ICacheMetricsCollector metricsCollector,
+    ILogger<CacheHealthChecker> logger,
+    IOptions<CacheMonitoringOptions> options)
+    : ICacheHealthChecker
+{
+    private readonly CacheMonitoringOptions _options = options.Value;
+
+    public async Task<CacheHealthStatus> CheckHealthAsync()
+    {
+        var healthStatus = new CacheHealthStatus();
+
+        try
+        {
+            // 현재 메트릭 수집
+            healthStatus.Metrics = await metricsCollector.CollectMetricsAsync();
+
+            // 각 컴포넌트 상태 확인
+            healthStatus.ComponentsHealth["Cache"] = await CheckCacheConnectionAsync();
+            healthStatus.ComponentsHealth["Memory"] = await CheckMemoryUsageAsync();
+            healthStatus.ComponentsHealth["Performance"] = await CheckPerformanceAsync();
+
+            // 전체 상태 결정
+            healthStatus.Status = DetermineOverallHealth(healthStatus);
+            healthStatus.Message = GetHealthMessage(healthStatus.Status);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Health check failed");
+            healthStatus.Status = HealthStatus.Critical;
+            healthStatus.Message = "Health check failed: " + ex.Message;
+        }
+
+        return healthStatus;
+    }
+
+    public async Task<HealthCheckResult> CheckComponentHealthAsync(string componentName)
+    {
+        return componentName.ToLower() switch
+        {
+            "cache" => await CheckCacheConnectionAsync(),
+            "memory" => await CheckMemoryUsageAsync(),
+            "performance" => await CheckPerformanceAsync(),
+            _ => new HealthCheckResult
+            {
+                Status = HealthStatus.Warning,
+                Message = "Unknown component"
+            }
+        };
+    }
+
+    private async Task<HealthCheckResult> CheckCacheConnectionAsync()
+    {
+        var startTime = DateTime.UtcNow;
+        try
+        {
+            // 테스트 키로 연결 확인
+            var testKey = $"health_check_{Guid.NewGuid()}";
+            var testValue = "test";
+
+            await cache.SetAsync(testKey, testValue, TimeSpan.FromSeconds(10));
+            var retrieved = await cache.GetAsync<string>(testKey);
+            await cache.RemoveAsync(testKey);
+
+            var responseTime = DateTime.UtcNow - startTime;
+
+            return new HealthCheckResult
+            {
+                Status = retrieved == testValue ? HealthStatus.Healthy : HealthStatus.Warning,
+                Message = retrieved == testValue ? "Cache connection healthy" : "Cache data mismatch",
+                ResponseTime = responseTime
+            };
+        }
+        catch (Exception ex)
+        {
+            return new HealthCheckResult
+            {
+                Status = HealthStatus.Critical,
+                Message = $"Cache connection failed: {ex.Message}",
+                ResponseTime = DateTime.UtcNow - startTime
+            };
+        }
+    }
+
+    private async Task<HealthCheckResult> CheckMemoryUsageAsync()
+    {
+        var metrics = await metricsCollector.CollectMetricsAsync();
+        var memoryUsage = metrics.MemoryUsageMB;
+        var threshold = _options.Thresholds.MaxMemoryUsageMB;
+
+        var status = memoryUsage switch
+        {
+            var usage when usage > threshold * 0.9 => HealthStatus.Critical,
+            var usage when usage > threshold * 0.8 => HealthStatus.Warning,
+            _ => HealthStatus.Healthy
+        };
+
+        return new HealthCheckResult
+        {
+            Status = status,
+            Message = $"Memory usage: {memoryUsage}MB / {threshold}MB",
+            Data = new Dictionary<string, object>
+            {
+                ["MemoryUsageMB"] = memoryUsage,
+                ["ThresholdMB"] = threshold,
+                ["UsagePercentage"] = (double)memoryUsage / threshold * 100
+            }
+        };
+    }
+
+    private async Task<HealthCheckResult> CheckPerformanceAsync()
+    {
+        var metrics = await metricsCollector.CollectMetricsAsync();
+        var responseTime = metrics.AverageResponseTimeMs;
+        var hitRatio = metrics.HitRatio;
+        var threshold = _options.Thresholds.MaxResponseTimeMs;
+        var minHitRatio = _options.Thresholds.MinHitRatio;
+
+        var status = HealthStatus.Healthy;
+        var messages = new List<string>();
+
+        if (responseTime > threshold * 1.5)
+        {
+            status = HealthStatus.Critical;
+            messages.Add($"Response time too high: {responseTime:F1}ms");
+        }
+        else if (responseTime > threshold)
+        {
+            status = HealthStatus.Warning;
+            messages.Add($"Response time elevated: {responseTime:F1}ms");
+        }
+
+        if (hitRatio < minHitRatio * 0.7)
+        {
+            status = HealthStatus.Critical;
+            messages.Add($"Hit ratio critically low: {hitRatio:P1}");
+        }
+        else if (hitRatio < minHitRatio)
+        {
+            if (status == HealthStatus.Healthy) status = HealthStatus.Warning;
+            messages.Add($"Hit ratio below target: {hitRatio:P1}");
+        }
+
+        return new HealthCheckResult
+        {
+            Status = status,
+            Message = messages.Any() ? string.Join(", ", messages) : "Performance healthy",
+            Data = new Dictionary<string, object>
+            {
+                ["ResponseTimeMs"] = responseTime,
+                ["HitRatio"] = hitRatio,
+                ["ResponseTimeThreshold"] = threshold,
+                ["HitRatioThreshold"] = minHitRatio
+            }
+        };
+    }
+
+    private static HealthStatus DetermineOverallHealth(CacheHealthStatus healthStatus)
+    {
+        var componentStatuses = healthStatus.ComponentsHealth.Values.Select(c => c.Status);
+
+        if (componentStatuses.Any(s => s == HealthStatus.Critical))
+            return HealthStatus.Critical;
+
+        if (componentStatuses.Any(s => s == HealthStatus.Warning))
+            return HealthStatus.Warning;
+
+        return HealthStatus.Healthy;
+    }
+
+    private static string GetHealthMessage(HealthStatus status)
+    {
+        return status switch
+        {
+            HealthStatus.Healthy => "All systems operational",
+            HealthStatus.Warning => "Some components need attention",
+            HealthStatus.Critical => "Critical issues detected",
+            HealthStatus.Offline => "System offline",
+            _ => "Unknown status"
+        };
+    }
+}

--- a/Athena.Cache.Monitoring/Collectors/MemoryCacheMetricsCollector.cs
+++ b/Athena.Cache.Monitoring/Collectors/MemoryCacheMetricsCollector.cs
@@ -1,0 +1,116 @@
+﻿using Athena.Cache.Monitoring.Interfaces;
+using Athena.Cache.Monitoring.Models;
+using System.Collections.Concurrent;
+using Athena.Cache.Core.Abstractions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Athena.Cache.Monitoring;
+
+/// <summary>
+/// 메모리 기반 메트릭 수집기
+/// </summary>
+public class MemoryCacheMetricsCollector(
+    IAthenaCache cache,
+    ILogger<MemoryCacheMetricsCollector> logger,
+    IOptions<CacheMonitoringOptions> options)
+    : ICacheMetricsCollector
+{
+    private readonly ConcurrentQueue<CacheMetrics> _metricsHistory = new();
+    private readonly IAthenaCache _cache = cache;
+    private readonly CacheMonitoringOptions _options = options.Value;
+
+    public async Task<CacheMetrics> CollectMetricsAsync()
+    {
+        try
+        {
+            var startTime = DateTime.UtcNow;
+
+            // 실제 캐시 시스템에서 메트릭 수집
+            var metrics = new CacheMetrics
+            {
+                Timestamp = DateTime.UtcNow,
+                // Redis나 기타 캐시에서 실제 메트릭 수집 로직
+                HitRatio = await CalculateHitRatioAsync(),
+                TotalRequests = await GetTotalRequestsAsync(),
+                AverageResponseTimeMs = await CalculateAverageResponseTimeAsync(),
+                MemoryUsageMB = await GetMemoryUsageAsync(),
+                ConnectionCount = await GetConnectionCountAsync(),
+                ErrorRate = await CalculateErrorRateAsync()
+            };
+
+            var endTime = DateTime.UtcNow;
+            logger.LogDebug("Metrics collection completed in {Duration}ms",
+                (endTime - startTime).TotalMilliseconds);
+
+            return metrics;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to collect cache metrics");
+            throw;
+        }
+    }
+
+    public Task<List<CacheMetrics>> GetMetricsHistoryAsync(DateTime startTime, DateTime endTime)
+    {
+        var history = _metricsHistory
+            .Where(m => m.Timestamp >= startTime && m.Timestamp <= endTime)
+            .OrderBy(m => m.Timestamp)
+            .ToList();
+
+        return Task.FromResult(history);
+    }
+
+    public Task RecordMetricsAsync(CacheMetrics metrics)
+    {
+        _metricsHistory.Enqueue(metrics);
+
+        // 오래된 메트릭 정리
+        var cutoffTime = DateTime.UtcNow - _options.MetricsRetentionPeriod;
+        while (_metricsHistory.TryPeek(out var oldMetrics) && oldMetrics.Timestamp < cutoffTime)
+        {
+            _metricsHistory.TryDequeue(out _);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    // 실제 메트릭 계산 메서드들 (캐시 구현체에 따라 달라짐)
+    private async Task<double> CalculateHitRatioAsync()
+    {
+        // 실제 구현에서는 캐시 백엔드에서 히트/미스 통계를 가져옴
+        await Task.Delay(1); // 비동기 시뮬레이션
+        return Random.Shared.NextDouble() * 0.3 + 0.7; // 70-100% 시뮬레이션
+    }
+
+    private async Task<long> GetTotalRequestsAsync()
+    {
+        await Task.Delay(1);
+        return Random.Shared.NextInt64(1000, 10000);
+    }
+
+    private async Task<double> CalculateAverageResponseTimeAsync()
+    {
+        await Task.Delay(1);
+        return Random.Shared.NextDouble() * 50 + 10; // 10-60ms 시뮬레이션
+    }
+
+    private async Task<long> GetMemoryUsageAsync()
+    {
+        await Task.Delay(1);
+        return Random.Shared.NextInt64(100, 500); // 100-500MB 시뮬레이션
+    }
+
+    private async Task<int> GetConnectionCountAsync()
+    {
+        await Task.Delay(1);
+        return Random.Shared.Next(50, 200);
+    }
+
+    private async Task<double> CalculateErrorRateAsync()
+    {
+        await Task.Delay(1);
+        return Random.Shared.NextDouble() * 0.02; // 0-2% 에러율 시뮬레이션
+    }
+}

--- a/Athena.Cache.Monitoring/Collectors/RedisCacheMetricsCollector.cs
+++ b/Athena.Cache.Monitoring/Collectors/RedisCacheMetricsCollector.cs
@@ -1,0 +1,108 @@
+﻿using Athena.Cache.Monitoring.Interfaces;
+using Athena.Cache.Monitoring.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Collections.Concurrent;
+using StackExchange.Redis;
+
+namespace Athena.Cache.Monitoring.Collectors;
+
+/// <summary>
+/// Redis 전용 메트릭 수집기 (Redis INFO 명령 활용)
+/// </summary>
+public class RedisCacheMetricsCollector(
+    IConnectionMultiplexer redis,
+    ILogger<RedisCacheMetricsCollector> logger,
+    IOptions<CacheMonitoringOptions> options)
+    : ICacheMetricsCollector
+{
+    private readonly CacheMonitoringOptions _options = options.Value;
+    private readonly ConcurrentQueue<CacheMetrics> _metricsHistory = new();
+
+    public async Task<CacheMetrics> CollectMetricsAsync()
+    {
+        try
+        {
+            var server = redis.GetServer(redis.GetEndPoints().First());
+            var info = await server.InfoAsync();
+
+            var metrics = new CacheMetrics
+            {
+                Timestamp = DateTime.UtcNow
+            };
+
+            // Redis INFO에서 메트릭 파싱
+            foreach (var section in info)
+            {
+                foreach (var item in section)
+                {
+                    switch (item.Key.ToLower())
+                    {
+                        case "keyspace_hits":
+                            if (long.TryParse(item.Value, out var hits))
+                                metrics.HitCount = hits;
+                            break;
+
+                        case "keyspace_misses":
+                            if (long.TryParse(item.Value, out var misses))
+                                metrics.MissCount = misses;
+                            break;
+
+                        case "used_memory":
+                            if (long.TryParse(item.Value, out var memory))
+                                metrics.MemoryUsageMB = memory / (1024 * 1024);
+                            break;
+
+                        case "connected_clients":
+                            if (int.TryParse(item.Value, out var connections))
+                                metrics.ConnectionCount = connections;
+                            break;
+                    }
+                }
+            }
+
+            // 계산된 메트릭
+            metrics.TotalRequests = metrics.HitCount + metrics.MissCount;
+            metrics.HitRatio = metrics.TotalRequests > 0
+                ? (double)metrics.HitCount / metrics.TotalRequests
+                : 0;
+
+            // 응답 시간 측정 (PING 명령 사용)
+            var database = redis.GetDatabase();
+            var pingStart = DateTime.UtcNow;
+            await database.PingAsync();
+            metrics.AverageResponseTimeMs = (DateTime.UtcNow - pingStart).TotalMilliseconds;
+
+            return metrics;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to collect Redis metrics");
+            throw;
+        }
+    }
+
+    public Task<List<CacheMetrics>> GetMetricsHistoryAsync(DateTime startTime, DateTime endTime)
+    {
+        var history = _metricsHistory
+            .Where(m => m.Timestamp >= startTime && m.Timestamp <= endTime)
+            .OrderBy(m => m.Timestamp)
+            .ToList();
+
+        return Task.FromResult(history);
+    }
+
+    public Task RecordMetricsAsync(CacheMetrics metrics)
+    {
+        _metricsHistory.Enqueue(metrics);
+
+        // 오래된 메트릭 정리
+        var cutoffTime = DateTime.UtcNow - _options.MetricsRetentionPeriod;
+        while (_metricsHistory.TryPeek(out var oldMetrics) && oldMetrics.Timestamp < cutoffTime)
+        {
+            _metricsHistory.TryDequeue(out _);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/Athena.Cache.Monitoring/Controllers/CacheMonitoringController.cs
+++ b/Athena.Cache.Monitoring/Controllers/CacheMonitoringController.cs
@@ -1,0 +1,252 @@
+﻿using Athena.Cache.Monitoring.Enums;
+using Athena.Cache.Monitoring.Interfaces;
+using Athena.Cache.Monitoring.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace Athena.Cache.Monitoring.Controllers;
+
+/// <summary>
+/// 캐시 모니터링 대시보드 API 컨트롤러
+/// </summary>
+[ApiController]
+[Route("api/cache/monitoring")]
+public class CacheMonitoringController(
+    ICacheMetricsCollector metricsCollector,
+    ICacheHealthChecker healthChecker,
+    ICacheAlertService alertService,
+    ILogger<CacheMonitoringController> logger)
+    : ControllerBase
+{
+    /// <summary>
+    /// 현재 캐시 메트릭 조회
+    /// </summary>
+    [HttpGet("metrics/current")]
+    public async Task<ActionResult<CacheMetrics>> GetCurrentMetrics()
+    {
+        try
+        {
+            var metrics = await metricsCollector.CollectMetricsAsync();
+            return Ok(metrics);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to get current metrics");
+            return StatusCode(500, new { error = "Failed to retrieve metrics" });
+        }
+    }
+
+    /// <summary>
+    /// 시계열 메트릭 데이터 조회
+    /// </summary>
+    [HttpGet("metrics/history")]
+    public async Task<ActionResult<List<CacheMetrics>>> GetMetricsHistory(
+        [FromQuery] DateTime? startTime = null,
+        [FromQuery] DateTime? endTime = null,
+        [FromQuery] int? intervalMinutes = null)
+    {
+        try
+        {
+            var start = startTime ?? DateTime.UtcNow.AddHours(-1);
+            var end = endTime ?? DateTime.UtcNow;
+
+            var history = await metricsCollector.GetMetricsHistoryAsync(start, end);
+
+            // 간격이 지정된 경우 데이터 샘플링
+            if (intervalMinutes.HasValue && intervalMinutes.Value > 0)
+            {
+                var interval = TimeSpan.FromMinutes(intervalMinutes.Value);
+                history = SampleMetrics(history, interval);
+            }
+
+            return Ok(history);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to get metrics history");
+            return StatusCode(500, new { error = "Failed to retrieve metrics history" });
+        }
+    }
+
+    /// <summary>
+    /// 캐시 상태 확인
+    /// </summary>
+    [HttpGet("health")]
+    public async Task<ActionResult<CacheHealthStatus>> GetHealthStatus()
+    {
+        try
+        {
+            var health = await healthChecker.CheckHealthAsync();
+            return Ok(health);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to get health status");
+            return StatusCode(500, new { error = "Failed to retrieve health status" });
+        }
+    }
+
+    /// <summary>
+    /// 개별 컴포넌트 상태 확인
+    /// </summary>
+    [HttpGet("health/{component}")]
+    public async Task<ActionResult<HealthCheckResult>> GetComponentHealth(string component)
+    {
+        try
+        {
+            var result = await healthChecker.CheckComponentHealthAsync(component);
+            return Ok(result);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to get component health for {Component}", component);
+            return StatusCode(500, new { error = $"Failed to check {component} health" });
+        }
+    }
+
+    /// <summary>
+    /// 대시보드 요약 정보
+    /// </summary>
+    [HttpGet("dashboard/summary")]
+    public async Task<ActionResult<object>> GetDashboardSummary()
+    {
+        try
+        {
+            var metrics = await metricsCollector.CollectMetricsAsync();
+            var health = await healthChecker.CheckHealthAsync();
+
+            var summary = new
+            {
+                timestamp = DateTime.UtcNow,
+                status = health.Status.ToString().ToLower(),
+                metrics = new
+                {
+                    hitRatio = metrics.HitRatio,
+                    totalRequests = metrics.TotalRequests,
+                    averageResponseTime = metrics.AverageResponseTimeMs,
+                    memoryUsage = metrics.MemoryUsageMB,
+                    connectionCount = metrics.ConnectionCount,
+                    errorRate = metrics.ErrorRate
+                },
+                components = health.ComponentsHealth.ToDictionary(
+                    kvp => kvp.Key.ToLower(),
+                    kvp => new
+                    {
+                        status = kvp.Value.Status.ToString().ToLower(),
+                        message = kvp.Value.Message,
+                        responseTime = kvp.Value.ResponseTime.TotalMilliseconds
+                    })
+            };
+
+            return Ok(summary);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to get dashboard summary");
+            return StatusCode(500, new { error = "Failed to retrieve dashboard summary" });
+        }
+    }
+
+    /// <summary>
+    /// 테스트 알림 발송
+    /// </summary>
+    [HttpPost("alerts/test")]
+    public async Task<ActionResult> SendTestAlert([FromBody] TestAlertRequest? request = null)
+    {
+        try
+        {
+            var alert = new CacheAlert
+            {
+                Level = request?.Level ?? AlertLevel.Info,
+                Title = request?.Title ?? "Test Alert",
+                Message = request?.Message ?? "This is a test alert from the monitoring system",
+                Component = request?.Component ?? "Monitoring"
+            };
+
+            await alertService.SendAlertAsync(alert);
+
+            return Ok(new
+            {
+                message = "Test alert sent successfully",
+                alertId = alert.Id,
+                timestamp = alert.Timestamp
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to send test alert");
+            return StatusCode(500, new { error = "Failed to send test alert" });
+        }
+    }
+
+    /// <summary>
+    /// 메트릭 데이터 샘플링 (대용량 데이터 처리용)
+    /// </summary>
+    private static List<CacheMetrics> SampleMetrics(List<CacheMetrics> metrics, TimeSpan interval)
+    {
+        if (!metrics.Any()) return metrics;
+
+        var sampled = new List<CacheMetrics>();
+        var currentBucket = metrics.First().Timestamp;
+        var bucketMetrics = new List<CacheMetrics>();
+
+        foreach (var metric in metrics)
+        {
+            if (metric.Timestamp - currentBucket >= interval)
+            {
+                // 현재 버킷의 평균 계산
+                if (bucketMetrics.Any())
+                {
+                    sampled.Add(new CacheMetrics
+                    {
+                        Timestamp = currentBucket,
+                        HitRatio = bucketMetrics.Average(m => m.HitRatio),
+                        TotalRequests = bucketMetrics.Sum(m => m.TotalRequests),
+                        HitCount = bucketMetrics.Sum(m => m.HitCount),
+                        MissCount = bucketMetrics.Sum(m => m.MissCount),
+                        AverageResponseTimeMs = bucketMetrics.Average(m => m.AverageResponseTimeMs),
+                        MemoryUsageMB = (long)bucketMetrics.Average(m => m.MemoryUsageMB),
+                        ConnectionCount = (int)bucketMetrics.Average(m => m.ConnectionCount),
+                        ErrorRate = bucketMetrics.Average(m => m.ErrorRate)
+                    });
+                }
+
+                // 새 버킷 시작
+                currentBucket = metric.Timestamp;
+                bucketMetrics.Clear();
+            }
+
+            bucketMetrics.Add(metric);
+        }
+
+        // 마지막 버킷 처리
+        if (bucketMetrics.Any())
+        {
+            sampled.Add(new CacheMetrics
+            {
+                Timestamp = currentBucket,
+                HitRatio = bucketMetrics.Average(m => m.HitRatio),
+                TotalRequests = bucketMetrics.Sum(m => m.TotalRequests),
+                HitCount = bucketMetrics.Sum(m => m.HitCount),
+                MissCount = bucketMetrics.Sum(m => m.MissCount),
+                AverageResponseTimeMs = bucketMetrics.Average(m => m.AverageResponseTimeMs),
+                MemoryUsageMB = (long)bucketMetrics.Average(m => m.MemoryUsageMB),
+                ConnectionCount = (int)bucketMetrics.Average(m => m.ConnectionCount),
+                ErrorRate = bucketMetrics.Average(m => m.ErrorRate)
+            });
+        }
+
+        return sampled;
+    }
+}
+
+/// <summary>
+/// 테스트 알림 요청 모델
+/// </summary>
+public class TestAlertRequest
+{
+    public AlertLevel Level { get; set; } = AlertLevel.Info;
+    public string Title { get; set; } = "Test Alert";
+    public string Message { get; set; } = "Test message";
+    public string Component { get; set; } = "Monitoring";
+}

--- a/Athena.Cache.Monitoring/Controllers/CacheMonitoringController.cs
+++ b/Athena.Cache.Monitoring/Controllers/CacheMonitoringController.cs
@@ -1,4 +1,5 @@
-﻿using Athena.Cache.Monitoring.Enums;
+﻿using Athena.Cache.Core.Abstractions;
+using Athena.Cache.Monitoring.Enums;
 using Athena.Cache.Monitoring.Interfaces;
 using Athena.Cache.Monitoring.Models;
 using Microsoft.AspNetCore.Mvc;
@@ -7,10 +8,12 @@ using Microsoft.Extensions.Logging;
 namespace Athena.Cache.Monitoring.Controllers;
 
 /// <summary>
-/// 캐시 모니터링 대시보드 API 컨트롤러
+/// 고급 캐시 모니터링 대시보드 API 컨트롤러
+/// 실시간 대시보드, 알림, 분석 기능 제공
+/// 기본 모니터링은 Athena.Cache.Core/Controllers/CacheMonitoringController 사용
 /// </summary>
 [ApiController]
-[Route("api/cache/monitoring")]
+[Route("api/athena-cache/monitoring/advanced")]
 public class CacheMonitoringController(
     ICacheMetricsCollector metricsCollector,
     ICacheHealthChecker healthChecker,
@@ -19,10 +22,10 @@ public class CacheMonitoringController(
     : ControllerBase
 {
     /// <summary>
-    /// 현재 캐시 메트릭 조회
+    /// 현재 확장 캐시 메트릭 조회 (고급 기능)
     /// </summary>
     [HttpGet("metrics/current")]
-    public async Task<ActionResult<CacheMetrics>> GetCurrentMetrics()
+    public async Task<ActionResult<IExtendedCacheMetrics>> GetCurrentMetrics()
     {
         try
         {
@@ -31,8 +34,8 @@ public class CacheMonitoringController(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to get current metrics");
-            return StatusCode(500, new { error = "Failed to retrieve metrics" });
+            logger.LogError(ex, "Failed to get current advanced metrics");
+            return StatusCode(500, new { error = "Failed to retrieve advanced metrics", details = ex.Message });
         }
     }
 
@@ -105,45 +108,78 @@ public class CacheMonitoringController(
     }
 
     /// <summary>
-    /// 대시보드 요약 정보
+    /// 고급 대시보드 요약 정보 - 실시간 분석 포함
     /// </summary>
     [HttpGet("dashboard/summary")]
-    public async Task<ActionResult<object>> GetDashboardSummary()
+    public async Task<ActionResult<AdvancedDashboardSummary>> GetDashboardSummary()
     {
         try
         {
             var metrics = await metricsCollector.CollectMetricsAsync();
             var health = await healthChecker.CheckHealthAsync();
+            var history = await metricsCollector.GetMetricsHistoryAsync(
+                DateTime.UtcNow.AddMinutes(-60), DateTime.UtcNow);
 
-            var summary = new
+            var summary = new AdvancedDashboardSummary
             {
-                timestamp = DateTime.UtcNow,
-                status = health.Status.ToString().ToLower(),
-                metrics = new
-                {
-                    hitRatio = metrics.HitRatio,
-                    totalRequests = metrics.TotalRequests,
-                    averageResponseTime = metrics.AverageResponseTimeMs,
-                    memoryUsage = metrics.MemoryUsageMB,
-                    connectionCount = metrics.ConnectionCount,
-                    errorRate = metrics.ErrorRate
-                },
-                components = health.ComponentsHealth.ToDictionary(
-                    kvp => kvp.Key.ToLower(),
-                    kvp => new
-                    {
-                        status = kvp.Value.Status.ToString().ToLower(),
-                        message = kvp.Value.Message,
-                        responseTime = kvp.Value.ResponseTime.TotalMilliseconds
-                    })
+                Timestamp = DateTime.UtcNow,
+                Status = health.Status.ToString().ToLower(),
+                CurrentMetrics = metrics,
+                HealthDetails = health,
+                PerformanceTrends = CalculatePerformanceTrends(history),
+                Recommendations = GenerateRecommendations(metrics, history)
             };
 
             return Ok(summary);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to get dashboard summary");
-            return StatusCode(500, new { error = "Failed to retrieve dashboard summary" });
+            logger.LogError(ex, "Failed to get advanced dashboard summary");
+            return StatusCode(500, new { error = "Failed to retrieve advanced dashboard summary", details = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// 실시간 메트릭 스트림 (WebSocket 대안)
+    /// </summary>
+    [HttpGet("metrics/stream")]
+    public async Task<ActionResult<object>> GetMetricsStream(
+        [FromQuery] int intervalSeconds = 5,
+        [FromQuery] int durationMinutes = 1)
+    {
+        try
+        {
+            if (intervalSeconds < 1 || intervalSeconds > 60)
+                return BadRequest(new { error = "intervalSeconds must be between 1 and 60" });
+            
+            if (durationMinutes < 1 || durationMinutes > 10)
+                return BadRequest(new { error = "durationMinutes must be between 1 and 10" });
+
+            var streamData = new List<IExtendedCacheMetrics>();
+            var endTime = DateTime.UtcNow.AddMinutes(durationMinutes);
+            
+            while (DateTime.UtcNow < endTime)
+            {
+                var metrics = await metricsCollector.CollectMetricsAsync();
+                streamData.Add(metrics);
+                
+                if (streamData.Count > 100) // 메모리 보호
+                    streamData.RemoveAt(0);
+                    
+                await Task.Delay(TimeSpan.FromSeconds(intervalSeconds));
+            }
+
+            return Ok(new
+            {
+                collectionPeriod = new { intervalSeconds, durationMinutes },
+                dataPoints = streamData.Count,
+                metrics = streamData
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to get metrics stream");
+            return StatusCode(500, new { error = "Failed to retrieve metrics stream", details = ex.Message });
         }
     }
 
@@ -179,6 +215,76 @@ public class CacheMonitoringController(
         }
     }
 
+    #region Advanced Analytics Helpers
+
+    /// <summary>
+    /// 성능 트렌드 계산
+    /// </summary>
+    private static PerformanceTrends CalculatePerformanceTrends(List<CacheMetrics> history)
+    {
+        if (!history.Any())
+            return new PerformanceTrends();
+
+        var recent = history.TakeLast(10).ToList();
+        var older = history.Take(history.Count - 10).TakeLast(10).ToList();
+
+        return new PerformanceTrends
+        {
+            HitRatioTrend = CalculateTrend(older.Average(m => m.HitRatio), recent.Average(m => m.HitRatio)),
+            ResponseTimeTrend = CalculateTrend(older.Average(m => m.AverageResponseTimeMs), recent.Average(m => m.AverageResponseTimeMs)),
+            MemoryUsageTrend = CalculateTrend(older.Average(m => m.MemoryUsageMB), recent.Average(m => m.MemoryUsageMB)),
+            ErrorRateTrend = CalculateTrend(older.Average(m => m.ErrorRate), recent.Average(m => m.ErrorRate))
+        };
+    }
+
+    /// <summary>
+    /// 트렌드 방향 계산
+    /// </summary>
+    private static string CalculateTrend(double oldValue, double newValue)
+    {
+        if (Math.Abs(oldValue - newValue) < 0.01) return "stable";
+        return newValue > oldValue ? "increasing" : "decreasing";
+    }
+
+    /// <summary>
+    /// 성능 개선 권장사항 생성
+    /// </summary>
+    private static List<string> GenerateRecommendations(CacheMetrics current, List<CacheMetrics> history)
+    {
+        var recommendations = new List<string>();
+
+        // 히트율 분석
+        if (current.HitRatio < 0.7)
+            recommendations.Add("캐시 히트율이 70% 미만입니다. 캐시 만료 시간을 늘리거나 키 전략을 검토하세요.");
+
+        // 응답 시간 분석
+        if (current.AverageResponseTimeMs > 100)
+            recommendations.Add("평균 응답시간이 100ms를 초과합니다. 캐시 성능 최적화를 고려하세요.");
+
+        // 메모리 사용량 분석
+        if (current.MemoryUsageMB > 1024)
+            recommendations.Add("메모리 사용량이 1GB를 초과합니다. 캐시 정리 정책을 검토하세요.");
+
+        // 에러율 분석
+        if (current.ErrorRate > 0.05)
+            recommendations.Add("에러율이 5%를 초과합니다. 캐시 설정과 연결 상태를 확인하세요.");
+
+        // 히스토리 기반 분석
+        if (history.Count >= 10)
+        {
+            var recent = history.TakeLast(5).Average(m => m.HitRatio);
+            var older = history.Take(5).Average(m => m.HitRatio);
+            
+            if (recent < older - 0.1)
+                recommendations.Add("최근 캐시 히트율이 하락하고 있습니다. 캐시 무효화 패턴을 확인하세요.");
+        }
+
+        if (!recommendations.Any())
+            recommendations.Add("현재 캐시 성능이 양호합니다.");
+
+        return recommendations;
+    }
+
     /// <summary>
     /// 메트릭 데이터 샘플링 (대용량 데이터 처리용)
     /// </summary>
@@ -197,18 +303,7 @@ public class CacheMonitoringController(
                 // 현재 버킷의 평균 계산
                 if (bucketMetrics.Any())
                 {
-                    sampled.Add(new CacheMetrics
-                    {
-                        Timestamp = currentBucket,
-                        HitRatio = bucketMetrics.Average(m => m.HitRatio),
-                        TotalRequests = bucketMetrics.Sum(m => m.TotalRequests),
-                        HitCount = bucketMetrics.Sum(m => m.HitCount),
-                        MissCount = bucketMetrics.Sum(m => m.MissCount),
-                        AverageResponseTimeMs = bucketMetrics.Average(m => m.AverageResponseTimeMs),
-                        MemoryUsageMB = (long)bucketMetrics.Average(m => m.MemoryUsageMB),
-                        ConnectionCount = (int)bucketMetrics.Average(m => m.ConnectionCount),
-                        ErrorRate = bucketMetrics.Average(m => m.ErrorRate)
-                    });
+                    sampled.Add(CreateSampledMetric(currentBucket, bucketMetrics));
                 }
 
                 // 새 버킷 시작
@@ -222,22 +317,36 @@ public class CacheMonitoringController(
         // 마지막 버킷 처리
         if (bucketMetrics.Any())
         {
-            sampled.Add(new CacheMetrics
-            {
-                Timestamp = currentBucket,
-                HitRatio = bucketMetrics.Average(m => m.HitRatio),
-                TotalRequests = bucketMetrics.Sum(m => m.TotalRequests),
-                HitCount = bucketMetrics.Sum(m => m.HitCount),
-                MissCount = bucketMetrics.Sum(m => m.MissCount),
-                AverageResponseTimeMs = bucketMetrics.Average(m => m.AverageResponseTimeMs),
-                MemoryUsageMB = (long)bucketMetrics.Average(m => m.MemoryUsageMB),
-                ConnectionCount = (int)bucketMetrics.Average(m => m.ConnectionCount),
-                ErrorRate = bucketMetrics.Average(m => m.ErrorRate)
-            });
+            sampled.Add(CreateSampledMetric(currentBucket, bucketMetrics));
         }
 
         return sampled;
     }
+
+    /// <summary>
+    /// 샘플링된 메트릭 생성
+    /// </summary>
+    private static CacheMetrics CreateSampledMetric(DateTime timestamp, List<CacheMetrics> bucketMetrics)
+    {
+        return new CacheMetrics
+        {
+            Timestamp = timestamp,
+            HitRatio = bucketMetrics.Average(m => m.HitRatio),
+            TotalRequests = bucketMetrics.Sum(m => m.TotalRequests),
+            HitCount = bucketMetrics.Sum(m => m.HitCount),
+            MissCount = bucketMetrics.Sum(m => m.MissCount),
+            AverageResponseTimeMs = bucketMetrics.Average(m => m.AverageResponseTimeMs),
+            MemoryUsageMB = (long)bucketMetrics.Average(m => m.MemoryUsageMB),
+            ConnectionCount = (int)bucketMetrics.Average(m => m.ConnectionCount),
+            ErrorRate = bucketMetrics.Average(m => m.ErrorRate),
+            ItemCount = (long)bucketMetrics.Average(m => m.ItemCount),
+            TotalErrors = bucketMetrics.Sum(m => m.TotalErrors),
+            HotKeysCount = (long)bucketMetrics.Average(m => m.HotKeysCount),
+            TotalInvalidations = bucketMetrics.Sum(m => m.TotalInvalidations)
+        };
+    }
+
+    #endregion
 }
 
 /// <summary>
@@ -249,4 +358,28 @@ public class TestAlertRequest
     public string Title { get; set; } = "Test Alert";
     public string Message { get; set; } = "Test message";
     public string Component { get; set; } = "Monitoring";
+}
+
+/// <summary>
+/// 고급 대시보드 요약 정보
+/// </summary>
+public class AdvancedDashboardSummary
+{
+    public DateTime Timestamp { get; init; }
+    public string Status { get; init; } = string.Empty;
+    public IExtendedCacheMetrics CurrentMetrics { get; init; } = null!;
+    public CacheHealthStatus HealthDetails { get; init; } = null!;
+    public PerformanceTrends PerformanceTrends { get; init; } = new();
+    public List<string> Recommendations { get; init; } = new();
+}
+
+/// <summary>
+/// 성능 트렌드 정보
+/// </summary>
+public class PerformanceTrends
+{
+    public string HitRatioTrend { get; init; } = "stable";
+    public string ResponseTimeTrend { get; init; } = "stable";
+    public string MemoryUsageTrend { get; init; } = "stable";
+    public string ErrorRateTrend { get; init; } = "stable";
 }

--- a/Athena.Cache.Monitoring/Enums/AlertLevel.cs
+++ b/Athena.Cache.Monitoring/Enums/AlertLevel.cs
@@ -1,0 +1,11 @@
+﻿namespace Athena.Cache.Monitoring.Enums;
+
+/// <summary>
+/// 알림 레벨
+/// </summary>
+public enum AlertLevel
+{
+    Info,
+    Warning,
+    Critical
+}

--- a/Athena.Cache.Monitoring/Enums/HealthStatus.cs
+++ b/Athena.Cache.Monitoring/Enums/HealthStatus.cs
@@ -1,0 +1,12 @@
+﻿namespace Athena.Cache.Monitoring.Enums;
+
+/// <summary>
+/// 상태 열거형
+/// </summary>
+public enum HealthStatus
+{
+    Healthy,
+    Warning,
+    Critical,
+    Offline
+}

--- a/Athena.Cache.Monitoring/Extensions/CacheMonitoringExtendedServiceCollectionExtensions.cs
+++ b/Athena.Cache.Monitoring/Extensions/CacheMonitoringExtendedServiceCollectionExtensions.cs
@@ -1,0 +1,75 @@
+﻿using Athena.Cache.Monitoring.Collectors;
+using Athena.Cache.Monitoring.Interfaces;
+using Athena.Cache.Monitoring.Models;
+using Athena.Cache.Monitoring.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Athena.Cache.Monitoring.Hubs;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+
+namespace Athena.Cache.Monitoring.Extensions;
+
+/// <summary>
+/// 확장된 캐시 모니터링 서비스 등록
+/// </summary>
+public static class CacheMonitoringExtendedServiceCollectionExtensions
+{
+    /// <summary>
+    /// Redis 기반 캐시 모니터링 등록
+    /// </summary>
+    public static IServiceCollection AddRedisCacheMonitoring(
+        this IServiceCollection services,
+        Action<CacheMonitoringOptions>? configure = null)
+    {
+        // 기본 모니터링 서비스 등록
+        services.AddAthenaCacheMonitoring(configure);
+
+        // Redis 전용 메트릭 수집기로 교체 (사용자가 이미 등록했다면 유지)
+        services.Replace(ServiceDescriptor.Singleton<ICacheMetricsCollector, RedisCacheMetricsCollector>());
+
+        return services;
+    }
+
+    /// <summary>
+    /// SignalR 기반 실시간 모니터링 등록
+    /// </summary>
+    public static IServiceCollection AddRealTimeCacheMonitoring(
+        this IServiceCollection services,
+        Action<CacheMonitoringOptions>? configure = null)
+    {
+        // 기본 모니터링 서비스 등록
+        services.AddAthenaCacheMonitoring(configure);
+
+        // SignalR 서비스 등록
+        services.TryAddSignalR();
+
+        services.AddKeyedSingleton<ICacheAlertService, CacheAlertService>("base");
+        services.Replace(ServiceDescriptor.Singleton<ICacheAlertService>(provider =>
+        {
+            var baseService = provider.GetRequiredKeyedService<ICacheAlertService>("base");
+            var hubContext = provider.GetRequiredService<IHubContext<CacheMonitoringHub>>();
+            var logger = provider.GetRequiredService<ILogger<SignalRCacheAlertService>>();
+
+            return new SignalRCacheAlertService(baseService, hubContext, logger);
+        }));
+
+        return services;
+    }
+
+    /// <summary>
+    /// 완전한 모니터링 스택 등록 (Redis + SignalR)
+    /// </summary>
+    public static IServiceCollection AddCompleteCacheMonitoring(
+        this IServiceCollection services,
+        Action<CacheMonitoringOptions>? configure = null)
+    {
+        // Redis 모니터링
+        services.AddRedisCacheMonitoring(configure);
+
+        // 실시간 모니터링
+        services.AddRealTimeCacheMonitoring();
+
+        return services;
+    }
+}

--- a/Athena.Cache.Monitoring/Extensions/CacheMonitoringServiceCollectionExtensions.cs
+++ b/Athena.Cache.Monitoring/Extensions/CacheMonitoringServiceCollectionExtensions.cs
@@ -1,0 +1,51 @@
+﻿using Athena.Cache.Monitoring.AlertChannels;
+using Athena.Cache.Monitoring.Interfaces;
+using Athena.Cache.Monitoring.Managers;
+using Athena.Cache.Monitoring.Models;
+using Athena.Cache.Monitoring.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+
+namespace Athena.Cache.Monitoring.Extensions;
+
+/// <summary>
+/// 캐시 모니터링 서비스 등록 확장 메서드
+/// </summary>
+public static class CacheMonitoringServiceCollectionExtensions
+{
+    /// <summary>
+    /// 캐시 모니터링 서비스 등록
+    /// </summary>
+    public static IServiceCollection AddAthenaCacheMonitoring(
+        this IServiceCollection services,
+        Action<CacheMonitoringOptions>? configure = null)
+    {
+        // 설정 등록
+        if (configure != null)
+        {
+            services.Configure(configure);
+        }
+        else
+        {
+            services.TryAddSingleton<CacheMonitoringOptions>();
+        }
+
+        // 기본 알림 채널들 등록
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IAlertChannel, LogAlertChannel>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IAlertChannel, ConsoleAlertChannel>());
+
+        // 알림 채널 관리자
+        services.TryAddSingleton<AlertChannelManager>();
+
+        // 모니터링 서비스들 등록
+        services.TryAddSingleton<ICacheMetricsCollector, MemoryCacheMetricsCollector>();
+        services.TryAddSingleton<ICacheHealthChecker, CacheHealthChecker>();
+        services.TryAddSingleton<ICacheAlertService, CacheAlertService>();
+
+        // 백그라운드 서비스 등록
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, CacheMonitoringBackgroundService>());
+
+        return services;
+    }
+}

--- a/Athena.Cache.Monitoring/Extensions/ServiceCollectionSignalRExtensions.cs
+++ b/Athena.Cache.Monitoring/Extensions/ServiceCollectionSignalRExtensions.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Athena.Cache.Monitoring.Extensions;
+
+public static class ServiceCollectionSignalRExtensions
+{
+    public static IServiceCollection TryAddSignalR(this IServiceCollection services)
+    {
+        // SignalR 서비스가 이미 등록되었는지 확인
+        if (!services.Any(x => x.ServiceType.Name.Contains("SignalR")))
+        {
+            services.AddSignalR();
+        }
+        return services;
+    }
+}

--- a/Athena.Cache.Monitoring/Hubs/CacheMonitoringHub.cs
+++ b/Athena.Cache.Monitoring/Hubs/CacheMonitoringHub.cs
@@ -1,0 +1,61 @@
+﻿using Athena.Cache.Monitoring.Interfaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Athena.Cache.Monitoring.Hubs;
+
+/// <summary>
+/// 실시간 캐시 모니터링 SignalR 허브
+/// </summary>
+public class CacheMonitoringHub(
+    ICacheMetricsCollector metricsCollector,
+    ICacheHealthChecker healthChecker,
+    ILogger<CacheMonitoringHub> logger)
+    : Hub
+{
+    public async Task JoinMonitoringGroup()
+    {
+        await Groups.AddToGroupAsync(Context.ConnectionId, "Monitoring");
+        logger.LogInformation("Client {ConnectionId} joined monitoring group", Context.ConnectionId);
+    }
+
+    public async Task LeaveMonitoringGroup()
+    {
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, "Monitoring");
+        logger.LogInformation("Client {ConnectionId} left monitoring group", Context.ConnectionId);
+    }
+
+    public async Task GetCurrentMetrics()
+    {
+        try
+        {
+            var metrics = await metricsCollector.CollectMetricsAsync();
+            await Clients.Caller.SendAsync("MetricsUpdate", metrics);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to send current metrics to client {ConnectionId}", Context.ConnectionId);
+            await Clients.Caller.SendAsync("Error", "Failed to retrieve metrics");
+        }
+    }
+
+    public async Task GetHealthStatus()
+    {
+        try
+        {
+            var health = await healthChecker.CheckHealthAsync();
+            await Clients.Caller.SendAsync("HealthUpdate", health);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to send health status to client {ConnectionId}", Context.ConnectionId);
+            await Clients.Caller.SendAsync("Error", "Failed to retrieve health status");
+        }
+    }
+
+    public override async Task OnDisconnectedAsync(Exception? exception)
+    {
+        logger.LogInformation("Client {ConnectionId} disconnected", Context.ConnectionId);
+        await base.OnDisconnectedAsync(exception);
+    }
+}

--- a/Athena.Cache.Monitoring/Interfaces/IAlertChannel.cs
+++ b/Athena.Cache.Monitoring/Interfaces/IAlertChannel.cs
@@ -1,0 +1,13 @@
+﻿using Athena.Cache.Monitoring.Models;
+
+namespace Athena.Cache.Monitoring.Interfaces;
+
+/// <summary>
+/// 알림 채널 추상화 인터페이스
+/// </summary>
+public interface IAlertChannel
+{
+    string Name { get; }
+    Task SendAsync(CacheAlert alert, CancellationToken cancellationToken = default);
+    Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default);
+}

--- a/Athena.Cache.Monitoring/Interfaces/ICacheAlertService.cs
+++ b/Athena.Cache.Monitoring/Interfaces/ICacheAlertService.cs
@@ -1,0 +1,24 @@
+﻿using Athena.Cache.Monitoring.Models;
+
+namespace Athena.Cache.Monitoring.Interfaces;
+
+/// <summary>
+/// 알림 서비스
+/// </summary>
+public interface ICacheAlertService
+{
+    /// <summary>
+    /// 알림 발송
+    /// </summary>
+    Task SendAlertAsync(CacheAlert alert);
+
+    /// <summary>
+    /// 메트릭 기반 자동 알림 확인
+    /// </summary>
+    Task CheckAlertsAsync(CacheMetrics metrics);
+
+    /// <summary>
+    /// 알림 구독
+    /// </summary>
+    event EventHandler<CacheAlert>? AlertRaised;
+}

--- a/Athena.Cache.Monitoring/Interfaces/ICacheHealthChecker.cs
+++ b/Athena.Cache.Monitoring/Interfaces/ICacheHealthChecker.cs
@@ -1,0 +1,19 @@
+﻿using Athena.Cache.Monitoring.Models;
+
+namespace Athena.Cache.Monitoring.Interfaces;
+
+/// <summary>
+/// 캐시 상태 확인 서비스
+/// </summary>
+public interface ICacheHealthChecker
+{
+    /// <summary>
+    /// 전체 캐시 상태 확인
+    /// </summary>
+    Task<CacheHealthStatus> CheckHealthAsync();
+
+    /// <summary>
+    /// 개별 컴포넌트 상태 확인
+    /// </summary>
+    Task<HealthCheckResult> CheckComponentHealthAsync(string componentName);
+}

--- a/Athena.Cache.Monitoring/Interfaces/ICacheMetricsCollector.cs
+++ b/Athena.Cache.Monitoring/Interfaces/ICacheMetricsCollector.cs
@@ -1,0 +1,24 @@
+﻿using Athena.Cache.Monitoring.Models;
+
+namespace Athena.Cache.Monitoring.Interfaces;
+
+/// <summary>
+/// 캐시 메트릭 수집기
+/// </summary>
+public interface ICacheMetricsCollector
+{
+    /// <summary>
+    /// 현재 메트릭 수집
+    /// </summary>
+    Task<CacheMetrics> CollectMetricsAsync();
+
+    /// <summary>
+    /// 시계열 메트릭 조회
+    /// </summary>
+    Task<List<CacheMetrics>> GetMetricsHistoryAsync(DateTime startTime, DateTime endTime);
+
+    /// <summary>
+    /// 메트릭 기록
+    /// </summary>
+    Task RecordMetricsAsync(CacheMetrics metrics);
+}

--- a/Athena.Cache.Monitoring/Managers/AlertChannelManager.cs
+++ b/Athena.Cache.Monitoring/Managers/AlertChannelManager.cs
@@ -1,0 +1,41 @@
+﻿using Athena.Cache.Monitoring.Interfaces;
+using Athena.Cache.Monitoring.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Athena.Cache.Monitoring.Managers;
+
+/// <summary>
+/// 알림 채널 관리자
+/// </summary>
+public class AlertChannelManager(
+    IEnumerable<IAlertChannel> channels,
+    ILogger<AlertChannelManager> logger)
+{
+    public async Task SendToAllChannelsAsync(CacheAlert alert)
+    {
+        var tasks = channels.Select(async channel =>
+        {
+            try
+            {
+                if (await channel.IsAvailableAsync())
+                {
+                    await channel.SendAsync(alert);
+                    logger.LogDebug("Alert sent successfully to {ChannelName}: {AlertId}",
+                        channel.Name, alert.Id);
+                }
+                else
+                {
+                    logger.LogWarning("Channel {ChannelName} is not available for alert: {AlertId}",
+                        channel.Name, alert.Id);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to send alert to {ChannelName}: {AlertId}",
+                    channel.Name, alert.Id);
+            }
+        });
+
+        await Task.WhenAll(tasks);
+    }
+}

--- a/Athena.Cache.Monitoring/Models/AlertThresholds.cs
+++ b/Athena.Cache.Monitoring/Models/AlertThresholds.cs
@@ -1,0 +1,32 @@
+﻿namespace Athena.Cache.Monitoring.Models;
+
+/// <summary>
+/// 알림 임계값 설정
+/// </summary>
+public class AlertThresholds
+{
+    /// <summary>
+    /// 캐시 히트율 최소값 (기본: 80%)
+    /// </summary>
+    public double MinHitRatio { get; set; } = 0.8;
+
+    /// <summary>
+    /// 최대 응답 시간 (밀리초, 기본: 100ms)
+    /// </summary>
+    public double MaxResponseTimeMs { get; set; } = 100;
+
+    /// <summary>
+    /// 최대 메모리 사용량 (MB, 기본: 1GB)
+    /// </summary>
+    public long MaxMemoryUsageMB { get; set; } = 1024;
+
+    /// <summary>
+    /// 최대 연결 수 (기본: 1000)
+    /// </summary>
+    public int MaxConnections { get; set; } = 1000;
+
+    /// <summary>
+    /// 에러율 최대값 (기본: 5%)
+    /// </summary>
+    public double MaxErrorRate { get; set; } = 0.05;
+}

--- a/Athena.Cache.Monitoring/Models/CacheAlert.cs
+++ b/Athena.Cache.Monitoring/Models/CacheAlert.cs
@@ -1,0 +1,17 @@
+﻿using Athena.Cache.Monitoring.Enums;
+
+namespace Athena.Cache.Monitoring.Models;
+
+/// <summary>
+/// 알림 이벤트
+/// </summary>
+public class CacheAlert
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+    public AlertLevel Level { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+    public string Component { get; set; } = string.Empty;
+    public Dictionary<string, object> Data { get; set; } = new();
+}

--- a/Athena.Cache.Monitoring/Models/CacheHealthStatus.cs
+++ b/Athena.Cache.Monitoring/Models/CacheHealthStatus.cs
@@ -1,0 +1,15 @@
+﻿using Athena.Cache.Monitoring.Enums;
+
+namespace Athena.Cache.Monitoring.Models;
+
+/// <summary>
+/// 캐시 상태 정보
+/// </summary>
+public class CacheHealthStatus
+{
+    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+    public HealthStatus Status { get; set; }
+    public string Message { get; set; } = string.Empty;
+    public Dictionary<string, HealthCheckResult> ComponentsHealth { get; set; } = new();
+    public CacheMetrics Metrics { get; set; } = new();
+}

--- a/Athena.Cache.Monitoring/Models/CacheMetrics.cs
+++ b/Athena.Cache.Monitoring/Models/CacheMetrics.cs
@@ -1,0 +1,18 @@
+﻿namespace Athena.Cache.Monitoring.Models;
+
+/// <summary>
+/// 실시간 캐시 메트릭
+/// </summary>
+public class CacheMetrics
+{
+    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+    public double HitRatio { get; set; }
+    public long TotalRequests { get; set; }
+    public long HitCount { get; set; }
+    public long MissCount { get; set; }
+    public double AverageResponseTimeMs { get; set; }
+    public long MemoryUsageMB { get; set; }
+    public int ConnectionCount { get; set; }
+    public double ErrorRate { get; set; }
+    public Dictionary<string, object> CustomMetrics { get; set; } = new();
+}

--- a/Athena.Cache.Monitoring/Models/CacheMetrics.cs
+++ b/Athena.Cache.Monitoring/Models/CacheMetrics.cs
@@ -1,9 +1,11 @@
-﻿namespace Athena.Cache.Monitoring.Models;
+﻿using Athena.Cache.Core.Abstractions;
+
+namespace Athena.Cache.Monitoring.Models;
 
 /// <summary>
-/// 실시간 캐시 메트릭
+/// 실시간 캐시 메트릭 - IExtendedCacheMetrics 구현
 /// </summary>
-public class CacheMetrics
+public class CacheMetrics : IExtendedCacheMetrics
 {
     public DateTime Timestamp { get; set; } = DateTime.UtcNow;
     public double HitRatio { get; set; }
@@ -14,5 +16,22 @@ public class CacheMetrics
     public long MemoryUsageMB { get; set; }
     public int ConnectionCount { get; set; }
     public double ErrorRate { get; set; }
-    public Dictionary<string, object> CustomMetrics { get; set; } = new();
+    private readonly Dictionary<string, object> _customMetrics = new();
+    
+    // ICacheMetrics 인터페이스 구현
+    public long TotalHits => HitCount;
+    public long TotalMisses => MissCount;
+    public long MemoryUsageBytes => MemoryUsageMB * 1024 * 1024;
+    public long ItemCount { get; set; }
+    public long TotalErrors { get; set; }
+    public long HotKeysCount { get; set; }
+    public long TotalInvalidations { get; set; }
+    
+    // IExtendedCacheMetrics 인터페이스 구현
+    public IReadOnlyDictionary<string, object> CustomMetrics => _customMetrics.AsReadOnly();
+    
+    // 하위 호환성을 위한 메서드
+    public Dictionary<string, object> GetMutableCustomMetrics() => _customMetrics;
+    public long DistributedInvalidationMessages { get; set; }
+    public string CircuitBreakerState { get; set; } = "Closed";
 }

--- a/Athena.Cache.Monitoring/Models/CacheMonitoringOptions.cs
+++ b/Athena.Cache.Monitoring/Models/CacheMonitoringOptions.cs
@@ -1,0 +1,32 @@
+﻿namespace Athena.Cache.Monitoring.Models;
+
+/// <summary>
+/// 캐시 모니터링 설정
+/// </summary>
+public class CacheMonitoringOptions
+{
+    /// <summary>
+    /// 메트릭 수집 간격 (기본: 30초)
+    /// </summary>
+    public TimeSpan MetricsCollectionInterval { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// 메트릭 보관 기간 (기본: 24시간)
+    /// </summary>
+    public TimeSpan MetricsRetentionPeriod { get; set; } = TimeSpan.FromHours(24);
+
+    /// <summary>
+    /// 알림 임계값 설정
+    /// </summary>
+    public AlertThresholds Thresholds { get; set; } = new();
+
+    /// <summary>
+    /// 상태 확인 간격 (기본: 5초)
+    /// </summary>
+    public TimeSpan HealthCheckInterval { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// SignalR를 통한 실시간 알림 활성화
+    /// </summary>
+    public bool EnableRealTimeNotifications { get; set; } = true;
+}

--- a/Athena.Cache.Monitoring/Models/HealthCheckResult.cs
+++ b/Athena.Cache.Monitoring/Models/HealthCheckResult.cs
@@ -1,0 +1,14 @@
+﻿using Athena.Cache.Monitoring.Enums;
+
+namespace Athena.Cache.Monitoring.Models;
+
+/// <summary>
+/// 개별 컴포넌트 상태 확인 결과
+/// </summary>
+public class HealthCheckResult
+{
+    public HealthStatus Status { get; set; }
+    public string Message { get; set; } = string.Empty;
+    public TimeSpan ResponseTime { get; set; }
+    public Dictionary<string, object> Data { get; set; } = new();
+}

--- a/Athena.Cache.Monitoring/Services/CacheAlertService.cs
+++ b/Athena.Cache.Monitoring/Services/CacheAlertService.cs
@@ -1,0 +1,153 @@
+﻿using Athena.Cache.Monitoring.Enums;
+using Athena.Cache.Monitoring.Interfaces;
+using Athena.Cache.Monitoring.Managers;
+using Athena.Cache.Monitoring.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Collections.Concurrent;
+using System.Text.Json;
+
+namespace Athena.Cache.Monitoring.Services;
+
+/// <summary>
+/// 캐시 알림 서비스
+/// </summary>
+public class CacheAlertService(
+    ILogger<CacheAlertService> logger,
+    IOptions<CacheMonitoringOptions> options,
+    AlertChannelManager channelManager)
+    : ICacheAlertService
+{
+    private readonly CacheMonitoringOptions _options = options.Value;
+    private readonly ConcurrentDictionary<string, DateTime> _lastAlertTimes = new();
+    private readonly TimeSpan _alertCooldown = TimeSpan.FromMinutes(5);
+
+    public event EventHandler<CacheAlert>? AlertRaised;
+
+    public async Task SendAlertAsync(CacheAlert alert)
+    {
+        try
+        {
+            // 쿨다운 체크
+            var alertKey = $"{alert.Component}_{alert.Level}";
+            if (_lastAlertTimes.TryGetValue(alertKey, out var lastTime))
+            {
+                if (DateTime.UtcNow - lastTime < _alertCooldown)
+                {
+                    return; // 쿨다운 중이므로 알림 스킵
+                }
+            }
+
+            _lastAlertTimes[alertKey] = DateTime.UtcNow;
+
+            // 이벤트 발생
+            AlertRaised?.Invoke(this, alert);
+
+            // 모든 채널로 알림 전송
+            await channelManager.SendToAllChannelsAsync(alert);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to send alert: {Alert}", JsonSerializer.Serialize(alert));
+        }
+    }
+
+    public async Task CheckAlertsAsync(CacheMetrics metrics)
+    {
+        var alerts = new List<CacheAlert>();
+
+        // 히트율 체크
+        if (metrics.HitRatio < _options.Thresholds.MinHitRatio)
+        {
+            var level = metrics.HitRatio < _options.Thresholds.MinHitRatio * 0.7
+                ? AlertLevel.Critical
+                : AlertLevel.Warning;
+
+            alerts.Add(new CacheAlert
+            {
+                Level = level,
+                Title = "Low Cache Hit Ratio",
+                Message =
+                    $"Cache hit ratio is {metrics.HitRatio:P1}, below threshold of {_options.Thresholds.MinHitRatio:P1}",
+                Component = "Performance",
+                Data = new Dictionary<string, object>
+                {
+                    ["HitRatio"] = metrics.HitRatio,
+                    ["Threshold"] = _options.Thresholds.MinHitRatio
+                }
+            });
+        }
+
+        // 응답 시간 체크
+        if (metrics.AverageResponseTimeMs > _options.Thresholds.MaxResponseTimeMs)
+        {
+            var level = metrics.AverageResponseTimeMs > _options.Thresholds.MaxResponseTimeMs * 2
+                ? AlertLevel.Critical
+                : AlertLevel.Warning;
+
+            alerts.Add(new CacheAlert
+            {
+                Level = level,
+                Title = "High Response Time",
+                Message =
+                    $"Average response time is {metrics.AverageResponseTimeMs:F1}ms, above threshold of {_options.Thresholds.MaxResponseTimeMs}ms",
+                Component = "Performance",
+                Data = new Dictionary<string, object>
+                {
+                    ["ResponseTimeMs"] = metrics.AverageResponseTimeMs,
+                    ["Threshold"] = _options.Thresholds.MaxResponseTimeMs
+                }
+            });
+        }
+
+        // 메모리 사용량 체크
+        if (metrics.MemoryUsageMB > _options.Thresholds.MaxMemoryUsageMB)
+        {
+            var level = metrics.MemoryUsageMB > _options.Thresholds.MaxMemoryUsageMB * 1.2
+                ? AlertLevel.Critical
+                : AlertLevel.Warning;
+
+            alerts.Add(new CacheAlert
+            {
+                Level = level,
+                Title = "High Memory Usage",
+                Message =
+                    $"Memory usage is {metrics.MemoryUsageMB}MB, above threshold of {_options.Thresholds.MaxMemoryUsageMB}MB",
+                Component = "Memory",
+                Data = new Dictionary<string, object>
+                {
+                    ["MemoryUsageMB"] = metrics.MemoryUsageMB,
+                    ["Threshold"] = _options.Thresholds.MaxMemoryUsageMB
+                }
+            });
+        }
+
+        // 에러율 체크
+        if (metrics.ErrorRate > _options.Thresholds.MaxErrorRate)
+        {
+            var level = metrics.ErrorRate > _options.Thresholds.MaxErrorRate * 2
+                ? AlertLevel.Critical
+                : AlertLevel.Warning;
+
+            alerts.Add(new CacheAlert
+            {
+                Level = level,
+                Title = "High Error Rate",
+                Message =
+                    $"Error rate is {metrics.ErrorRate:P1}, above threshold of {_options.Thresholds.MaxErrorRate:P1}",
+                Component = "Reliability",
+                Data = new Dictionary<string, object>
+                {
+                    ["ErrorRate"] = metrics.ErrorRate,
+                    ["Threshold"] = _options.Thresholds.MaxErrorRate
+                }
+            });
+        }
+
+        // 알림 발송
+        foreach (var alert in alerts)
+        {
+            await SendAlertAsync(alert);
+        }
+    }
+}

--- a/Athena.Cache.Monitoring/Services/CacheMonitoringBackgroundService.cs
+++ b/Athena.Cache.Monitoring/Services/CacheMonitoringBackgroundService.cs
@@ -1,0 +1,51 @@
+﻿using Athena.Cache.Monitoring.Interfaces;
+using Athena.Cache.Monitoring.Models;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Athena.Cache.Monitoring.Services;
+
+/// <summary>
+/// 백그라운드에서 지속적으로 모니터링을 수행하는 서비스
+/// </summary>
+public class CacheMonitoringBackgroundService(
+    ICacheMetricsCollector metricsCollector,
+    ICacheHealthChecker healthChecker,
+    ICacheAlertService alertService,
+    ILogger<CacheMonitoringBackgroundService> logger,
+    IOptions<CacheMonitoringOptions> options)
+    : BackgroundService
+{
+    private readonly ICacheHealthChecker _healthChecker = healthChecker;
+    private readonly CacheMonitoringOptions _options = options.Value;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation("Cache monitoring background service started");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                // 메트릭 수집 및 기록
+                var metrics = await metricsCollector.CollectMetricsAsync();
+                await metricsCollector.RecordMetricsAsync(metrics);
+
+                // 알림 확인
+                await alertService.CheckAlertsAsync(metrics);
+
+                logger.LogDebug("Cache monitoring cycle completed. Hit ratio: {HitRatio:P1}, Response time: {ResponseTime:F1}ms",
+                    metrics.HitRatio, metrics.AverageResponseTimeMs);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error during cache monitoring cycle");
+            }
+
+            await Task.Delay(_options.MetricsCollectionInterval, stoppingToken);
+        }
+
+        logger.LogInformation("Cache monitoring background service stopped");
+    }
+}

--- a/Athena.Cache.Monitoring/Services/SignalRCacheAlertService.cs
+++ b/Athena.Cache.Monitoring/Services/SignalRCacheAlertService.cs
@@ -1,0 +1,45 @@
+﻿using Athena.Cache.Monitoring.Hubs;
+using Athena.Cache.Monitoring.Interfaces;
+using Athena.Cache.Monitoring.Models;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+
+namespace Athena.Cache.Monitoring.Services;
+
+/// <summary>
+/// SignalR를 통한 실시간 알림 서비스
+/// </summary>
+public class SignalRCacheAlertService(
+    ICacheAlertService baseAlertService,
+    IHubContext<CacheMonitoringHub> hubContext,
+    ILogger<SignalRCacheAlertService> logger)
+    : ICacheAlertService
+{
+    public event EventHandler<CacheAlert>? AlertRaised
+    {
+        add => baseAlertService.AlertRaised += value;
+        remove => baseAlertService.AlertRaised -= value;
+    }
+
+    public async Task SendAlertAsync(CacheAlert alert)
+    {
+        // 기본 알림 서비스 호출
+        await baseAlertService.SendAlertAsync(alert);
+
+        // SignalR를 통한 실시간 알림
+        try
+        {
+            await hubContext.Clients.Group("Monitoring").SendAsync("AlertReceived", alert);
+            logger.LogDebug("Alert sent via SignalR: {AlertId}", alert.Id);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to send alert via SignalR: {AlertId}", alert.Id);
+        }
+    }
+
+    public Task CheckAlertsAsync(CacheMetrics metrics)
+    {
+        return baseAlertService.CheckAlertsAsync(metrics);
+    }
+}

--- a/Athena.Cache.Redis/DistributedCacheInvalidator.cs
+++ b/Athena.Cache.Redis/DistributedCacheInvalidator.cs
@@ -3,6 +3,7 @@ using Athena.Cache.Core.Configuration;
 using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
 using System.Text.Json;
+using Athena.Cache.Core.Enums;
 
 namespace Athena.Cache.Redis;
 

--- a/Athena.Cache.Redis/DistributedCacheInvalidator.cs
+++ b/Athena.Cache.Redis/DistributedCacheInvalidator.cs
@@ -1,0 +1,321 @@
+using Athena.Cache.Core.Abstractions;
+using Athena.Cache.Core.Configuration;
+using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
+using System.Text.Json;
+
+namespace Athena.Cache.Redis;
+
+/// <summary>
+/// Redis Pub/Sub 기반 분산 캐시 무효화 구현
+/// </summary>
+public class DistributedCacheInvalidator : IDistributedCacheInvalidator, IDisposable
+{
+    private readonly IConnectionMultiplexer _redis;
+    private readonly IDatabase _database;
+    private readonly ISubscriber _subscriber;
+    private readonly ICacheInvalidator _localInvalidator;
+    private readonly AthenaCacheOptions _options;
+    private readonly ILogger<DistributedCacheInvalidator> _logger;
+    
+    private readonly string _channelPrefix;
+    private readonly SemaphoreSlim _connectionSemaphore = new(1, 1);
+    private volatile bool _isListening = false;
+    private volatile bool _disposed = false;
+
+    public string InstanceId { get; }
+    public bool IsConnected => _redis.IsConnected;
+    
+    public event EventHandler<InvalidationEventArgs>? InvalidationReceived;
+
+    public DistributedCacheInvalidator(
+        IConnectionMultiplexer redis,
+        ICacheInvalidator localInvalidator,
+        AthenaCacheOptions options,
+        ILogger<DistributedCacheInvalidator> logger)
+    {
+        _redis = redis ?? throw new ArgumentNullException(nameof(redis));
+        _localInvalidator = localInvalidator ?? throw new ArgumentNullException(nameof(localInvalidator));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        
+        _database = _redis.GetDatabase();
+        _subscriber = _redis.GetSubscriber();
+        
+        InstanceId = Environment.MachineName + "_" + Environment.ProcessId + "_" + Guid.NewGuid().ToString("N")[..8];
+        _channelPrefix = $"{_options.Namespace}:invalidation";
+        
+        _logger.LogInformation("DistributedCacheInvalidator initialized with InstanceId: {InstanceId}", InstanceId);
+    }
+
+    #region IDistributedCacheInvalidator Implementation
+
+    public async Task StartListeningAsync(CancellationToken cancellationToken = default)
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(DistributedCacheInvalidator));
+        
+        await _connectionSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_isListening) return;
+
+            var channel = new RedisChannel(_channelPrefix, RedisChannel.PatternMode.Literal);
+            await _subscriber.SubscribeAsync(channel, OnInvalidationMessageReceived).ConfigureAwait(false);
+            
+            _isListening = true;
+            _logger.LogInformation("Started listening for distributed invalidation messages on channel: {Channel}", _channelPrefix);
+        }
+        finally
+        {
+            _connectionSemaphore.Release();
+        }
+    }
+
+    public async Task StopListeningAsync(CancellationToken cancellationToken = default)
+    {
+        if (_disposed) return;
+        
+        await _connectionSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (!_isListening) return;
+
+            var channel = new RedisChannel(_channelPrefix, RedisChannel.PatternMode.Literal);
+            await _subscriber.UnsubscribeAsync(channel).ConfigureAwait(false);
+            
+            _isListening = false;
+            _logger.LogInformation("Stopped listening for distributed invalidation messages");
+        }
+        finally
+        {
+            _connectionSemaphore.Release();
+        }
+    }
+
+    public async Task BroadcastInvalidationAsync(string tableName, CancellationToken cancellationToken = default)
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(DistributedCacheInvalidator));
+
+        var message = new InvalidationMessage
+        {
+            Type = InvalidationType.Table,
+            TableNames = [tableName],
+            CorrelationId = Guid.NewGuid().ToString()
+        };
+
+        await BroadcastMessageAsync(message, cancellationToken).ConfigureAwait(false);
+        _logger.LogDebug("Broadcasted table invalidation for: {TableName}", tableName);
+    }
+
+    public async Task BroadcastInvalidationByPatternAsync(string pattern, CancellationToken cancellationToken = default)
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(DistributedCacheInvalidator));
+
+        var message = new InvalidationMessage
+        {
+            Type = InvalidationType.Pattern,
+            TableNames = [],
+            Pattern = pattern,
+            CorrelationId = Guid.NewGuid().ToString()
+        };
+
+        await BroadcastMessageAsync(message, cancellationToken).ConfigureAwait(false);
+        _logger.LogDebug("Broadcasted pattern invalidation for: {Pattern}", pattern);
+    }
+
+    public async Task BroadcastBatchInvalidationAsync(IEnumerable<string> tableNames, CancellationToken cancellationToken = default)
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(DistributedCacheInvalidator));
+
+        var tables = tableNames.ToArray();
+        if (tables.Length == 0) return;
+
+        var message = new InvalidationMessage
+        {
+            Type = InvalidationType.Batch,
+            TableNames = tables,
+            CorrelationId = Guid.NewGuid().ToString()
+        };
+
+        await BroadcastMessageAsync(message, cancellationToken).ConfigureAwait(false);
+        _logger.LogDebug("Broadcasted batch invalidation for {Count} tables", tables.Length);
+    }
+
+    #endregion
+
+    #region ICacheInvalidator Implementation (Delegated to local + broadcast)
+
+    public async Task InvalidateAsync(string tableName, CancellationToken cancellationToken = default)
+    {
+        // 로컬 무효화
+        await _localInvalidator.InvalidateAsync(tableName, cancellationToken).ConfigureAwait(false);
+        
+        // 분산 브로드캐스트
+        await BroadcastInvalidationAsync(tableName, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task InvalidateByPatternAsync(string pattern, CancellationToken cancellationToken = default)
+    {
+        // 로컬 무효화
+        await _localInvalidator.InvalidateByPatternAsync(pattern, cancellationToken).ConfigureAwait(false);
+        
+        // 분산 브로드캐스트
+        await BroadcastInvalidationByPatternAsync(pattern, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task InvalidateBatchAsync(IEnumerable<string> tableNames, CancellationToken cancellationToken = default)
+    {
+        // 로컬 무효화
+        await _localInvalidator.InvalidateBatchAsync(tableNames, cancellationToken).ConfigureAwait(false);
+        
+        // 분산 브로드캐스트
+        await BroadcastBatchInvalidationAsync(tableNames, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task InvalidateByPatternBatchAsync(IEnumerable<string> patterns, CancellationToken cancellationToken = default)
+    {
+        // 로컬 무효화
+        await _localInvalidator.InvalidateByPatternBatchAsync(patterns, cancellationToken).ConfigureAwait(false);
+        
+        // 각 패턴별로 분산 브로드캐스트
+        var patternArray = patterns.ToArray();
+        var tasks = patternArray.Select(pattern => BroadcastInvalidationByPatternAsync(pattern, cancellationToken));
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+    }
+
+    public Task TrackCacheKeyAsync(string tableName, string cacheKey, CancellationToken cancellationToken = default)
+    {
+        return _localInvalidator.TrackCacheKeyAsync(tableName, cacheKey, cancellationToken);
+    }
+
+    public Task TrackCacheKeyAsync(string[] tableNames, string cacheKey, CancellationToken cancellationToken = default)
+    {
+        return _localInvalidator.TrackCacheKeyAsync(tableNames, cacheKey, cancellationToken);
+    }
+
+    public Task<IEnumerable<string>> GetTrackedKeysAsync(string tableName, CancellationToken cancellationToken = default)
+    {
+        return _localInvalidator.GetTrackedKeysAsync(tableName, cancellationToken);
+    }
+
+    public Task InvalidateWithRelatedAsync(string tableName, string[] relatedTables, int maxDepth = 3, CancellationToken cancellationToken = default)
+    {
+        return _localInvalidator.InvalidateWithRelatedAsync(tableName, relatedTables, maxDepth, cancellationToken);
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    private async Task BroadcastMessageAsync(InvalidationMessage message, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var envelope = new InvalidationEnvelope
+            {
+                SourceInstanceId = InstanceId,
+                Message = message,
+                Timestamp = DateTime.UtcNow
+            };
+
+            var json = JsonSerializer.Serialize(envelope, JsonSerializerOptions.Web);
+            var channel = new RedisChannel(_channelPrefix, RedisChannel.PatternMode.Literal);
+            
+            await _subscriber.PublishAsync(channel, json).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to broadcast invalidation message: {MessageType}", message.Type);
+            throw;
+        }
+    }
+
+    private async void OnInvalidationMessageReceived(RedisChannel channel, RedisValue message)
+    {
+        try
+        {
+            if (!message.HasValue) return;
+
+            var envelope = JsonSerializer.Deserialize<InvalidationEnvelope>(message.ToString(), JsonSerializerOptions.Web);
+            if (envelope == null) return;
+
+            // 자신이 보낸 메시지는 무시
+            if (envelope.SourceInstanceId == InstanceId) return;
+
+            _logger.LogDebug("Received invalidation message from {SourceInstance}: {MessageType}", 
+                envelope.SourceInstanceId, envelope.Message.Type);
+
+            // 로컬 무효화 실행 (브로드캐스트하지 않음)
+            await ProcessInvalidationMessageAsync(envelope.Message).ConfigureAwait(false);
+
+            // 이벤트 발생
+            InvalidationReceived?.Invoke(this, new InvalidationEventArgs
+            {
+                SourceInstanceId = envelope.SourceInstanceId,
+                Message = envelope.Message,
+                Timestamp = envelope.Timestamp
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error processing invalidation message from channel {Channel}", channel);
+        }
+    }
+
+    private async Task ProcessInvalidationMessageAsync(InvalidationMessage message)
+    {
+        switch (message.Type)
+        {
+            case InvalidationType.Table:
+                foreach (var tableName in message.TableNames)
+                {
+                    await _localInvalidator.InvalidateAsync(tableName).ConfigureAwait(false);
+                }
+                break;
+
+            case InvalidationType.Pattern:
+                if (!string.IsNullOrEmpty(message.Pattern))
+                {
+                    await _localInvalidator.InvalidateByPatternAsync(message.Pattern).ConfigureAwait(false);
+                }
+                break;
+
+            case InvalidationType.Batch:
+                await _localInvalidator.InvalidateBatchAsync(message.TableNames).ConfigureAwait(false);
+                break;
+        }
+    }
+
+    #endregion
+
+    #region IDisposable
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+
+        try
+        {
+            StopListeningAsync().GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during disposal");
+        }
+
+        _connectionSemaphore?.Dispose();
+        _disposed = true;
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// Redis 메시지 전송용 봉투 클래스
+/// </summary>
+internal class InvalidationEnvelope
+{
+    public required string SourceInstanceId { get; init; }
+    public required InvalidationMessage Message { get; init; }
+    public DateTime Timestamp { get; init; }
+}

--- a/Athena.Cache.Redis/Extensions/ServiceCollectionExtensions.cs
+++ b/Athena.Cache.Redis/Extensions/ServiceCollectionExtensions.cs
@@ -1,7 +1,9 @@
 ﻿using Athena.Cache.Core.Abstractions;
 using Athena.Cache.Core.Configuration;
 using Athena.Cache.Core.Extensions;
+using Athena.Cache.Core.Implementations;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
 
 namespace Athena.Cache.Redis.Extensions;
@@ -56,5 +58,61 @@ public static class ServiceCollectionExtensions
         return services
             .AddAthenaCacheRedis(configureAthena, configureRedis)
             .AddAthenaCacheActionFilter();
+    }
+
+    /// <summary>
+    /// Redis 기반 분산 캐시 무효화 시스템 등록
+    /// </summary>
+    public static IServiceCollection AddAthenaCacheRedisDistributed(
+        this IServiceCollection services,
+        Action<AthenaCacheOptions>? configureAthena = null,
+        Action<RedisCacheOptions>? configureRedis = null)
+    {
+        // 기본 Redis 캐시 등록
+        services.AddAthenaCacheRedis(configureAthena, configureRedis);
+
+        // 지능형 캐시 관리자 등록
+        services.AddSingleton<IIntelligentCacheManager, IntelligentCacheManager>();
+
+        // 기존 로컬 무효화기를 분산 무효화기로 교체
+        services.AddSingleton<ICacheInvalidator>(provider =>
+        {
+            var cache = provider.GetRequiredService<IAthenaCache>();
+            var keyGenerator = provider.GetRequiredService<ICacheKeyGenerator>();
+            var options = provider.GetRequiredService<AthenaCacheOptions>();
+            var logger = provider.GetRequiredService<ILogger<DefaultCacheInvalidator>>();
+            
+            // 로컬 무효화기 생성
+            var localInvalidator = new DefaultCacheInvalidator(cache, keyGenerator, options, logger);
+            
+            // Redis 연결 및 분산 무효화기 생성
+            var redis = provider.GetRequiredService<IConnectionMultiplexer>();
+            var distributedLogger = provider.GetRequiredService<ILogger<DistributedCacheInvalidator>>();
+
+            return new DistributedCacheInvalidator(redis, localInvalidator, options, distributedLogger);
+        });
+
+        // 분산 무효화기도 별도로 등록 (명시적 사용을 위해)
+        services.AddSingleton<IDistributedCacheInvalidator>(provider =>
+            (IDistributedCacheInvalidator)provider.GetRequiredService<ICacheInvalidator>());
+
+        return services;
+    }
+
+    /// <summary>
+    /// Redis 기반 엔터프라이즈 캐시 시스템 등록 (분산 무효화 + 지능형 관리)
+    /// </summary>
+    public static IServiceCollection AddAthenaCacheRedisEnterprise(
+        this IServiceCollection services,
+        Action<AthenaCacheOptions>? configureAthena = null,
+        Action<RedisCacheOptions>? configureRedis = null)
+    {
+        // 분산 캐시 시스템 등록
+        services.AddAthenaCacheRedisDistributed(configureAthena, configureRedis);
+
+        // 액션 필터도 추가
+        services.AddAthenaCacheActionFilter();
+
+        return services;
     }
 }

--- a/Athena.Cache.Sample/Controllers/OrdersController.cs
+++ b/Athena.Cache.Sample/Controllers/OrdersController.cs
@@ -12,11 +12,10 @@ public class OrdersController(IOrderService orderService, ILogger<OrdersControll
     : ControllerBase
 {
     /// <summary>
-    /// 주문 목록 조회 (Orders, Users 테이블과 연관)
+    /// 주문 목록 조회 (Convention 기반 Orders + 명시적 Users 테이블과 연관)
     /// </summary>
     [HttpGet]
     [AthenaCache(ExpirationMinutes = 20)]
-    [CacheInvalidateOn("Orders")]
     [CacheInvalidateOn("Users", InvalidationType.Related, "Orders")]
     public async Task<ActionResult<IEnumerable<OrderDto>>> GetOrders(
         [FromQuery] int? userId = null,
@@ -30,11 +29,10 @@ public class OrdersController(IOrderService orderService, ILogger<OrdersControll
     }
 
     /// <summary>
-    /// 특정 주문 조회
+    /// 특정 주문 조회 (Convention 기반 Orders + 명시적 Users 테이블 변경 시 무효화)
     /// </summary>
     [HttpGet("{id}")]
     [AthenaCache(ExpirationMinutes = 45)]
-    [CacheInvalidateOn("Orders")]
     [CacheInvalidateOn("Users")]
     public async Task<ActionResult<OrderDto>> GetOrder(int id)
     {
@@ -48,9 +46,10 @@ public class OrdersController(IOrderService orderService, ILogger<OrdersControll
     }
 
     /// <summary>
-    /// 주문 생성
+    /// 주문 생성 (Convention 기반 Orders + 명시적 Users 테이블 무효화)
     /// </summary>
     [HttpPost]
+    [CacheInvalidateOn("Users", InvalidationType.Related, "Orders")]
     public async Task<ActionResult<OrderDto>> CreateOrder([FromBody] Order order)
     {
         if (!ModelState.IsValid)
@@ -63,9 +62,10 @@ public class OrdersController(IOrderService orderService, ILogger<OrdersControll
     }
 
     /// <summary>
-    /// 주문 삭제
+    /// 주문 삭제 (Convention 기반 Orders + 명시적 Users 테이블 무효화)
     /// </summary>
     [HttpDelete("{id}")]
+    [CacheInvalidateOn("Users", InvalidationType.Related, "Orders")]
     public async Task<ActionResult> DeleteOrder(int id)
     {
         var deleted = await orderService.DeleteOrderAsync(id);

--- a/Athena.Cache.Sample/Controllers/ReportsController.cs
+++ b/Athena.Cache.Sample/Controllers/ReportsController.cs
@@ -1,0 +1,121 @@
+using Athena.Cache.Core.Abstractions;
+using Athena.Cache.Core.Attributes;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Athena.Cache.Sample.Controllers;
+
+/// <summary>
+/// Convention 기반 추론을 비활성화한 컨트롤러 예제
+/// 캐싱은 사용하지만, 무효화는 수동으로 제어
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+[NoConventionInvalidation]  // Convention 기반 추론 비활성화
+public class ReportsController(ICacheInvalidator cacheInvalidator, ILogger<ReportsController> logger) : ControllerBase
+{
+    /// <summary>
+    /// 보고서 데이터 조회 (캐싱만, 자동 무효화 없음)
+    /// </summary>
+    [HttpGet("monthly")]
+    [AthenaCache(ExpirationMinutes = 120)]
+    public async Task<ActionResult<object>> GetMonthlyReport([FromQuery] int year = 2024, [FromQuery] int month = 1)
+    {
+        logger.LogInformation("GetMonthlyReport called with year: {Year}, month: {Month}", year, month);
+
+        // 실제로는 데이터베이스에서 복잡한 집계 쿼리 실행
+        await Task.Delay(100); // 시뮬레이션
+        
+        var report = new
+        {
+            Year = year,
+            Month = month,
+            TotalUsers = 1500,
+            TotalOrders = 3200,
+            Revenue = 125000.50m,
+            GeneratedAt = DateTime.UtcNow
+        };
+
+        return Ok(report);
+    }
+
+    /// <summary>
+    /// 연간 보고서 조회 (명시적으로 특정 테이블만 무효화)
+    /// </summary>
+    [HttpGet("yearly")]
+    [AthenaCache(ExpirationMinutes = 240)]
+    [CacheInvalidateOn("UserStatistics")]  // Convention 없이 명시적으로만
+    [CacheInvalidateOn("OrderStatistics")]
+    public async Task<ActionResult<object>> GetYearlyReport([FromQuery] int year = 2024)
+    {
+        logger.LogInformation("GetYearlyReport called with year: {Year}", year);
+
+        await Task.Delay(200); // 시뮬레이션
+        
+        var report = new
+        {
+            Year = year,
+            TotalUsers = 18000,
+            TotalOrders = 45000,
+            Revenue = 1850000.75m,
+            GeneratedAt = DateTime.UtcNow
+        };
+
+        return Ok(report);
+    }
+
+    /// <summary>
+    /// 보고서 데이터 새로 고침 (수동 캐시 무효화)
+    /// </summary>
+    [HttpPost("refresh")]
+    public async Task<ActionResult> RefreshReportData([FromQuery] string? reportType = null)
+    {
+        logger.LogInformation("RefreshReportData called with reportType: {ReportType}", reportType);
+
+        // 수동으로 캐시 무효화
+        switch (reportType?.ToLower())
+        {
+            case "monthly":
+                await cacheInvalidator.InvalidateByPatternAsync("*GetMonthlyReport*");
+                logger.LogInformation("Monthly report cache invalidated");
+                break;
+                
+            case "yearly":
+                await cacheInvalidator.InvalidateByPatternAsync("*GetYearlyReport*");
+                logger.LogInformation("Yearly report cache invalidated");
+                break;
+                
+            case null:
+            case "all":
+                await cacheInvalidator.InvalidateByPatternAsync("*Report*");
+                logger.LogInformation("All report caches invalidated");
+                break;
+                
+            default:
+                return BadRequest($"Unknown report type: {reportType}");
+        }
+
+        return Ok(new { Message = "Report cache refreshed successfully", ReportType = reportType ?? "all" });
+    }
+
+    /// <summary>
+    /// 캐시 없이 실시간 데이터 조회
+    /// </summary>
+    [HttpGet("realtime")]
+    [NoCache]
+    public async Task<ActionResult<object>> GetRealtimeData()
+    {
+        logger.LogInformation("GetRealtimeData called - 캐시 없이 실시간 데이터");
+
+        await Task.Delay(50); // 시뮬레이션
+        
+        var data = new
+        {
+            CurrentActiveUsers = Random.Shared.Next(100, 500),
+            PendingOrders = Random.Shared.Next(10, 50),
+            ServerLoad = Random.Shared.NextDouble() * 100,
+            Timestamp = DateTime.UtcNow
+        };
+
+        return Ok(data);
+    }
+}

--- a/Athena.Cache.Sample/Controllers/ZeroMemoryDemoController.cs
+++ b/Athena.Cache.Sample/Controllers/ZeroMemoryDemoController.cs
@@ -1,0 +1,343 @@
+using Athena.Cache.Core.Analytics;
+using Athena.Cache.Core.Memory;
+using Microsoft.AspNetCore.Mvc;
+using System.Diagnostics;
+
+namespace Athena.Cache.Sample.Controllers;
+
+/// <summary>
+/// 제로 메모리 할당 최적화 데모 컨트롤러
+/// 실제 성능 향상을 확인할 수 있는 API들을 제공
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+public class ZeroMemoryDemoController : ControllerBase
+{
+    private readonly MemoryPressureManager _memoryManager;
+    private readonly ILogger<ZeroMemoryDemoController> _logger;
+
+    public ZeroMemoryDemoController(
+        MemoryPressureManager memoryManager,
+        ILogger<ZeroMemoryDemoController> logger)
+    {
+        _memoryManager = memoryManager;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// 메모리 상태 및 캐시 통계 조회
+    /// </summary>
+    [HttpGet("memory-status")]
+    public ActionResult<object> GetMemoryStatus()
+    {
+        var memoryStatus = _memoryManager.GetMemoryStatus();
+        var cacheStats = LazyCache.GetCacheStats();
+        var poolStats = HighPerformanceStringPool.GetPoolStats();
+
+        return Ok(new
+        {
+            timestamp = DateTime.UtcNow,
+            memory = new
+            {
+                totalBytes = memoryStatus.TotalMemoryBytes,
+                formattedSize = LazyCache.FormatByteSize(memoryStatus.TotalMemoryBytes),
+                pressureLevel = memoryStatus.PressureLevel.ToString(),
+                lastCleanup = memoryStatus.LastCleanupTime
+            },
+            gc = new
+            {
+                gen0Collections = memoryStatus.GcStatistics.Gen0Collections,
+                gen1Collections = memoryStatus.GcStatistics.Gen1Collections,
+                gen2Collections = memoryStatus.GcStatistics.Gen2Collections,
+                gen0Frequency = memoryStatus.GcStatistics.Gen0Frequency,
+                gen1Frequency = memoryStatus.GcStatistics.Gen1Frequency,
+                gen2Frequency = memoryStatus.GcStatistics.Gen2Frequency
+            },
+            cache = new
+            {
+                totalCacheSize = cacheStats.TotalCacheSize,
+                stringCache = cacheStats.StringCacheSize,
+                intCache = cacheStats.IntCacheSize,
+                percentageCache = cacheStats.PercentageCacheSize,
+                byteSizeCache = cacheStats.ByteSizeCacheSize
+            },
+            stringPool = new
+            {
+                poolCount = poolStats.StringBuilderPoolCount,
+                internCount = poolStats.InternPoolCount,
+                templateCount = poolStats.TemplateCacheCount,
+                estimatedMemory = poolStats.EstimatedMemoryUsage,
+                formattedMemory = LazyCache.FormatByteSize(poolStats.EstimatedMemoryUsage)
+            }
+        });
+    }
+
+    /// <summary>
+    /// 기존 방식 vs 최적화된 방식 성능 비교 테스트
+    /// </summary>
+    [HttpPost("performance-comparison")]
+    public ActionResult<object> PerformanceComparison([FromQuery] int iterations = 10000)
+    {
+        var results = new Dictionary<string, object>();
+
+        // 1. 문자열 포맷팅 비교
+        results["stringFormatting"] = CompareStringFormatting(iterations);
+
+        // 2. 컬렉션 생성 비교
+        results["collectionCreation"] = CompareCollectionCreation(iterations);
+
+        // 3. 통계 계산 비교
+        results["statisticsCalculation"] = CompareStatisticsCalculation(iterations);
+
+        // 4. 메모리 사용량 비교
+        results["memoryUsage"] = CompareMemoryUsage(iterations);
+
+        return Ok(results);
+    }
+
+    /// <summary>
+    /// 메모리 압박 시뮬레이션 및 자동 정리 테스트
+    /// </summary>
+    [HttpPost("memory-pressure-test")]
+    public ActionResult<object> MemoryPressureTest()
+    {
+        var initialMemory = GC.GetTotalMemory(false);
+        var initialStats = _memoryManager.GetMemoryStatus();
+
+        // 대량의 메모리 할당으로 의도적 압박 생성
+        var memoryHogs = new List<byte[]>();
+        for (int i = 0; i < 100; i++)
+        {
+            memoryHogs.Add(new byte[1024 * 1024]); // 1MB씩 할당
+        }
+
+        var peakMemory = GC.GetTotalMemory(false);
+
+        // 강제 정리 수행
+        _memoryManager.ForceCleanup(MemoryPressureLevel.High);
+
+        // 할당된 메모리 해제
+        memoryHogs.Clear();
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        var finalMemory = GC.GetTotalMemory(true);
+        var finalStats = _memoryManager.GetMemoryStatus();
+
+        return Ok(new
+        {
+            test = "Memory pressure simulation",
+            initialMemory = LazyCache.FormatByteSize(initialMemory),
+            peakMemory = LazyCache.FormatByteSize(peakMemory),
+            finalMemory = LazyCache.FormatByteSize(finalMemory),
+            memoryFreed = LazyCache.FormatByteSize(peakMemory - finalMemory),
+            initialPressure = initialStats.PressureLevel.ToString(),
+            finalPressure = finalStats.PressureLevel.ToString(),
+            gcImprovement = new
+            {
+                gen0Reduced = Math.Max(0, initialStats.GcStatistics.Gen0Frequency - finalStats.GcStatistics.Gen0Frequency),
+                gen1Reduced = Math.Max(0, initialStats.GcStatistics.Gen1Frequency - finalStats.GcStatistics.Gen1Frequency),
+                gen2Reduced = Math.Max(0, initialStats.GcStatistics.Gen2Frequency - finalStats.GcStatistics.Gen2Frequency)
+            }
+        });
+    }
+
+    /// <summary>
+    /// 캐시 정리 수행
+    /// </summary>
+    [HttpPost("clear-caches")]
+    public ActionResult<object> ClearCaches()
+    {
+        var beforeStats = LazyCache.GetCacheStats();
+        var beforePoolStats = HighPerformanceStringPool.GetPoolStats();
+
+        LazyCache.ClearCaches();
+        HighPerformanceStringPool.ClearAllPools();
+
+        var afterStats = LazyCache.GetCacheStats();
+        var afterPoolStats = HighPerformanceStringPool.GetPoolStats();
+
+        return Ok(new
+        {
+            message = "All caches and pools cleared",
+            before = new
+            {
+                cacheSize = beforeStats.TotalCacheSize,
+                poolMemory = beforePoolStats.EstimatedMemoryUsage
+            },
+            after = new
+            {
+                cacheSize = afterStats.TotalCacheSize,
+                poolMemory = afterPoolStats.EstimatedMemoryUsage
+            },
+            freed = new
+            {
+                cacheItems = beforeStats.TotalCacheSize - afterStats.TotalCacheSize,
+                memoryBytes = beforePoolStats.EstimatedMemoryUsage - afterPoolStats.EstimatedMemoryUsage
+            }
+        });
+    }
+
+    private object CompareStringFormatting(int iterations)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        // 기존 방식
+        stopwatch.Restart();
+        for (int i = 0; i < iterations; i++)
+        {
+            var ratio = i / (double)iterations;
+            var result = $"{ratio:P1}"; // 표준 포맷팅
+        }
+        var oldWayTime = stopwatch.ElapsedMilliseconds;
+
+        // 최적화된 방식
+        stopwatch.Restart();
+        for (int i = 0; i < iterations; i++)
+        {
+            var ratio = i / (double)iterations;
+            var result = LazyCache.FormatPercentage(ratio); // 캐싱된 포맷팅
+        }
+        var newWayTime = stopwatch.ElapsedMilliseconds;
+
+        return new
+        {
+            test = "String formatting",
+            iterations,
+            oldWayMs = oldWayTime,
+            newWayMs = newWayTime,
+            improvement = oldWayTime > 0 ? $"{(double)(oldWayTime - newWayTime) / oldWayTime * 100:F1}%" : "N/A"
+        };
+    }
+
+    private object CompareCollectionCreation(int iterations)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        // 기존 방식
+        stopwatch.Restart();
+        for (int i = 0; i < iterations; i++)
+        {
+            var list = new List<string>(); // 매번 새로 생성
+            list.Add("test");
+            list.Clear();
+        }
+        var oldWayTime = stopwatch.ElapsedMilliseconds;
+
+        // 최적화된 방식
+        stopwatch.Restart();
+        for (int i = 0; i < iterations; i++)
+        {
+            var list = CollectionPools.RentStringList(); // 풀에서 재사용
+            try
+            {
+                list.Add("test");
+            }
+            finally
+            {
+                CollectionPools.Return(list);
+            }
+        }
+        var newWayTime = stopwatch.ElapsedMilliseconds;
+
+        return new
+        {
+            test = "Collection creation",
+            iterations,
+            oldWayMs = oldWayTime,
+            newWayMs = newWayTime,
+            improvement = oldWayTime > 0 ? $"{(double)(oldWayTime - newWayTime) / oldWayTime * 100:F1}%" : "N/A"
+        };
+    }
+
+    private object CompareStatisticsCalculation(int iterations)
+    {
+        var data = Enumerable.Range(1, 1000).Select(x => (double)x).ToArray();
+        var stopwatch = Stopwatch.StartNew();
+
+        // 기존 방식 (LINQ)
+        stopwatch.Restart();
+        for (int i = 0; i < iterations; i++)
+        {
+            var average = data.Average(); // LINQ - 새 열거자 생성
+        }
+        var oldWayTime = stopwatch.ElapsedMilliseconds;
+
+        // 최적화된 방식 (값 타입)
+        stopwatch.Restart();
+        for (int i = 0; i < iterations; i++)
+        {
+            var average = ValueTypeStatistics.CalculateAverage<double>(data); // 값 타입 처리
+        }
+        var newWayTime = stopwatch.ElapsedMilliseconds;
+
+        return new
+        {
+            test = "Statistics calculation",
+            iterations,
+            oldWayMs = oldWayTime,
+            newWayMs = newWayTime,
+            improvement = oldWayTime > 0 ? $"{(double)(oldWayTime - newWayTime) / oldWayTime * 100:F1}%" : "N/A"
+        };
+    }
+
+    private object CompareMemoryUsage(int iterations)
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        // 기존 방식 메모리 사용량
+        var initialMemory = GC.GetTotalMemory(false);
+        for (int i = 0; i < iterations; i++)
+        {
+            var list = new List<string>();
+            list.Add($"Item {i}");
+            var result = string.Join(",", list);
+        }
+        var oldWayMemory = GC.GetTotalMemory(true) - initialMemory;
+
+        // 최적화된 방식 메모리 사용량
+        initialMemory = GC.GetTotalMemory(false);
+        for (int i = 0; i < iterations; i++)
+        {
+            var list = CollectionPools.RentStringList();
+            try
+            {
+                list.Add(LazyCache.InternString($"Item {i}"));
+                var sb = HighPerformanceStringPool.RentStringBuilder();
+                try
+                {
+                    foreach (var item in list)
+                    {
+                        if (sb.Length > 0) sb.Append(',');
+                        sb.Append(item);
+                    }
+                    var result = sb.ToString();
+                }
+                finally
+                {
+                    HighPerformanceStringPool.ReturnStringBuilder(sb);
+                }
+            }
+            finally
+            {
+                CollectionPools.Return(list);
+            }
+        }
+        var newWayMemory = GC.GetTotalMemory(true) - initialMemory;
+
+        return new
+        {
+            test = "Memory usage",
+            iterations,
+            oldWayBytes = Math.Max(0, oldWayMemory),
+            newWayBytes = Math.Max(0, newWayMemory),
+            oldWayFormatted = LazyCache.FormatByteSize(Math.Max(0, oldWayMemory)),
+            newWayFormatted = LazyCache.FormatByteSize(Math.Max(0, newWayMemory)),
+            memoryReduction = oldWayMemory > 0 && newWayMemory >= 0 ? 
+                $"{(double)(oldWayMemory - newWayMemory) / oldWayMemory * 100:F1}%" : "N/A"
+        };
+    }
+}

--- a/Athena.Cache.Sample/Program.cs
+++ b/Athena.Cache.Sample/Program.cs
@@ -1,4 +1,6 @@
 using Athena.Cache.Core.Extensions;
+using Athena.Cache.Core.Memory;
+using Athena.Cache.Redis.Extensions;
 using Athena.Cache.Sample.Data;
 using Athena.Cache.Sample.Services;
 using Microsoft.EntityFrameworkCore;
@@ -29,25 +31,11 @@ builder.Services.AddDbContext<SampleDbContext>(options =>
 builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<IOrderService, OrderService>();
 
-// Athena Cache 설정 - Redis 테스트용
-//builder.Services.AddAthenaCacheRedisComplete(
-//    athena =>
-//    {
-//        athena.Namespace = "SampleApp_REDIS_TEST";
-//        athena.VersionKey = "v1.0";
-//        athena.DefaultExpirationMinutes = 30;
-//        athena.Logging.LogCacheHitMiss = true;
-//        athena.Logging.LogInvalidation = true;
-//        athena.Logging.LogKeyGeneration = true;
-//    },
-//    redis =>
-//    {
-//        redis.ConnectionString = "localhost:6379";
-//        redis.DatabaseId = 2;
-//        redis.KeyPrefix = "test";
-//    });
+// 제로 메모리 최적화 관련 서비스 등록
+builder.Services.AddSingleton<MemoryPressureManager>();
 
-builder.Services.AddAthenaCacheComplete(
+// Athena Cache 설정 - Redis 테스트용
+builder.Services.AddAthenaCacheRedisComplete(
     athena =>
     {
         athena.Namespace = "SampleApp_REDIS_TEST";
@@ -56,7 +44,24 @@ builder.Services.AddAthenaCacheComplete(
         athena.Logging.LogCacheHitMiss = true;
         athena.Logging.LogInvalidation = true;
         athena.Logging.LogKeyGeneration = true;
+    },
+    redis =>
+    {
+        redis.ConnectionString = "localhost:6379";
+        redis.DatabaseId = 2;
+        redis.KeyPrefix = "test";
     });
+
+//builder.Services.AddAthenaCacheComplete(
+//    athena =>
+//    {
+//        athena.Namespace = "SampleApp_REDIS_TEST";
+//        athena.VersionKey = "v1.0";
+//        athena.DefaultExpirationMinutes = 30;
+//        athena.Logging.LogCacheHitMiss = true;
+//        athena.Logging.LogInvalidation = true;
+//        athena.Logging.LogKeyGeneration = true;
+//    });
 
 var app = builder.Build();
 

--- a/Athena.Cache.Sample/Program.cs
+++ b/Athena.Cache.Sample/Program.cs
@@ -1,5 +1,4 @@
 using Athena.Cache.Core.Extensions;
-using Athena.Cache.Redis.Extensions;
 using Athena.Cache.Sample.Data;
 using Athena.Cache.Sample.Services;
 using Microsoft.EntityFrameworkCore;

--- a/Athena.Cache.SourceGenerator/AthenaCacheSourceGenerator.cs
+++ b/Athena.Cache.SourceGenerator/AthenaCacheSourceGenerator.cs
@@ -1,10 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Text;
 
 namespace Athena.Cache.SourceGenerator;

--- a/Athena.Cache.Tests/Integration/RedisCacheTests.cs
+++ b/Athena.Cache.Tests/Integration/RedisCacheTests.cs
@@ -1,5 +1,3 @@
 ﻿namespace Athena.Cache.Tests.Integration;
 
-internal class RedisCacheTests
-{
-}
+internal class RedisCacheTests;

--- a/Athena.Cache.Tests/Integration/WebApplicationIntegrationTests.cs
+++ b/Athena.Cache.Tests/Integration/WebApplicationIntegrationTests.cs
@@ -228,9 +228,9 @@ public class BasicFunctionalityTests
         var serviceProvider = services.BuildServiceProvider();
 
         // Act & Assert - 서비스가 등록되었는지 확인
-        var cache = serviceProvider.GetService<Athena.Cache.Core.Abstractions.IAthenaCache>();
-        var invalidator = serviceProvider.GetService<Athena.Cache.Core.Abstractions.ICacheInvalidator>();
-        var keyGenerator = serviceProvider.GetService<Athena.Cache.Core.Abstractions.ICacheKeyGenerator>();
+        var cache = serviceProvider.GetService<Core.Abstractions.IAthenaCache>();
+        var invalidator = serviceProvider.GetService<Core.Abstractions.ICacheInvalidator>();
+        var keyGenerator = serviceProvider.GetService<Core.Abstractions.ICacheKeyGenerator>();
 
         cache.Should().NotBeNull();
         invalidator.Should().NotBeNull();
@@ -247,8 +247,8 @@ public class BasicFunctionalityTests
         services.AddAthenaCacheComplete();
 
         var serviceProvider = services.BuildServiceProvider();
-        var cache = serviceProvider.GetRequiredService<Athena.Cache.Core.Abstractions.IAthenaCache>();
-        var invalidator = serviceProvider.GetRequiredService<Athena.Cache.Core.Abstractions.ICacheInvalidator>();
+        var cache = serviceProvider.GetRequiredService<Core.Abstractions.IAthenaCache>();
+        var invalidator = serviceProvider.GetRequiredService<Core.Abstractions.ICacheInvalidator>();
 
         // Act & Assert - 기본 캐시 작업
         var testKey = "test_key";
@@ -326,8 +326,8 @@ public class TestUserService
 public class TestUsersController(TestUserService userService) : Microsoft.AspNetCore.Mvc.ControllerBase
 {
     [Microsoft.AspNetCore.Mvc.HttpGet]
-    [Athena.Cache.Core.Attributes.AthenaCache(ExpirationMinutes = 10)]
-    [Athena.Cache.Core.Attributes.CacheInvalidateOn("Users")]
+    [Core.Attributes.AthenaCache(ExpirationMinutes = 10)]
+    [Core.Attributes.CacheInvalidateOn("Users")]
     public async Task<Microsoft.AspNetCore.Mvc.ActionResult<IEnumerable<TestUser>>> GetUsers(
         [Microsoft.AspNetCore.Mvc.FromQuery] int? minAge = null)
     {
@@ -336,8 +336,8 @@ public class TestUsersController(TestUserService userService) : Microsoft.AspNet
     }
 
     [Microsoft.AspNetCore.Mvc.HttpGet("{id}")]
-    [Athena.Cache.Core.Attributes.AthenaCache(ExpirationMinutes = 15)]
-    [Athena.Cache.Core.Attributes.CacheInvalidateOn("Users")]
+    [Core.Attributes.AthenaCache(ExpirationMinutes = 15)]
+    [Core.Attributes.CacheInvalidateOn("Users")]
     public async Task<Microsoft.AspNetCore.Mvc.ActionResult<TestUser>> GetUser(int id)
     {
         var user = await userService.GetUserByIdAsync(id);
@@ -362,12 +362,12 @@ public class TestUsersController(TestUserService userService) : Microsoft.AspNet
 [Microsoft.AspNetCore.Mvc.ApiController]
 [Microsoft.AspNetCore.Mvc.Route("api/[controller]")]
 public class TestCacheController(
-    Athena.Cache.Core.Abstractions.IAthenaCache cache,
-    Athena.Cache.Core.Abstractions.ICacheInvalidator invalidator)
+    Core.Abstractions.IAthenaCache cache,
+    Core.Abstractions.ICacheInvalidator invalidator)
     : Microsoft.AspNetCore.Mvc.ControllerBase
 {
     [Microsoft.AspNetCore.Mvc.HttpGet("statistics")]
-    public async Task<Microsoft.AspNetCore.Mvc.ActionResult<Athena.Cache.Core.Abstractions.CacheStatistics>> GetStatistics()
+    public async Task<Microsoft.AspNetCore.Mvc.ActionResult<Core.Abstractions.CacheStatistics>> GetStatistics()
     {
         var stats = await cache.GetStatisticsAsync();
         return Ok(stats);

--- a/Athena.Cache.Tests/Performance/HashPerformanceTests.cs
+++ b/Athena.Cache.Tests/Performance/HashPerformanceTests.cs
@@ -9,12 +9,12 @@ using System.Text;
 namespace Athena.Cache.Tests.Performance;
 
 /// <summary>
-/// SHA256 vs XxHash64 성능 비교 테스트
+/// SHA256 vs XxHash3 성능 비교 테스트
 /// </summary>
 public class HashPerformanceTests
 {
     [Fact]
-    public async Task XxHash64_vs_SHA256_HashingPerformance()
+    public async Task XxHash3_vs_SHA256_HashingPerformance()
     {
         // Arrange
         const int iterations = 10000;
@@ -31,14 +31,14 @@ public class HashPerformanceTests
         {
             Console.WriteLine($"\n=== 입력 크기: {input.Length} bytes ===");
             
-            // XxHash64 성능 측정
+            // XxHash3 성능 측정
             var stopwatch = Stopwatch.StartNew();
             ulong xxHashResult = 0;
             
             for (int i = 0; i < iterations; i++)
             {
                 var inputBytes = Encoding.UTF8.GetBytes(input);
-                xxHashResult = XxHash64.HashToUInt64(inputBytes);
+                xxHashResult = XxHash3.HashToUInt64(inputBytes);
             }
             
             var xxHashTime = stopwatch.ElapsedMilliseconds;
@@ -56,18 +56,18 @@ public class HashPerformanceTests
             var sha256Time = stopwatch.ElapsedMilliseconds;
 
             // 결과 출력
-            Console.WriteLine($"XxHash64: {xxHashTime}ms (결과: {xxHashResult})");
+            Console.WriteLine($"XxHash3: {xxHashTime}ms (결과: {xxHashResult})");
             Console.WriteLine($"SHA256: {sha256Time}ms (결과: {Convert.ToHexString(sha256Result)[..16]}...)");
             Console.WriteLine($"성능 향상: {(double)sha256Time / xxHashTime:F1}x 빠름");
             
-            // 성능 검증 - 전체적으로 XxHash64가 더 빠르거나 비슷해야 함 (작은 데이터에서는 초기화 오버헤드로 인해 차이가 적을 수 있음)
+            // 성능 검증 - 전체적으로 XxHash3가 더 빠르거나 비슷해야 함 (작은 데이터에서는 초기화 오버헤드로 인해 차이가 적을 수 있음)
             if (input.Length > 100) // 큰 데이터에서만 엄격한 성능 검증
             {
-                xxHashTime.Should().BeLessThan(sha256Time, "XxHash64가 SHA256보다 빨라야 함 (큰 데이터)");
+                xxHashTime.Should().BeLessThan(sha256Time, "XxHash3가 SHA256보다 빨라야 함 (큰 데이터)");
             }
             else
             {
-                xxHashTime.Should().BeLessThanOrEqualTo(sha256Time * 2, "XxHash64가 SHA256보다 2배 이상 느리지 않아야 함 (작은 데이터)");
+                xxHashTime.Should().BeLessThanOrEqualTo(sha256Time * 2, "XxHash3가 SHA256보다 2배 이상 느리지 않아야 함 (작은 데이터)");
             }
         }
     }
@@ -83,7 +83,7 @@ public class HashPerformanceTests
             VersionKey = "v2.0"
         };
         
-        // XxHash64 기반 키 생성기 (새 구현)
+        // XxHash3 기반 키 생성기 (새 구현)
         var newKeyGenerator = new DefaultCacheKeyGenerator(options);
         
         var testParameters = new Dictionary<string, object?>[]
@@ -118,7 +118,7 @@ public class HashPerformanceTests
             generatedKeys.Should().HaveCount(1, "같은 파라미터는 같은 키를 생성해야 함");
             
             // 결과 출력
-            Console.WriteLine($"XxHash64 + 캐싱: {newTime}ms");
+            Console.WriteLine($"XxHash3 + 캐싱: {newTime}ms");
             Console.WriteLine($"평균 시간/키: {(double)newTime / iterations:F4}ms");
             Console.WriteLine($"생성된 키: {generatedKeys.First()}");
         }

--- a/Athena.Cache.Tests/Performance/HashPerformanceTests.cs
+++ b/Athena.Cache.Tests/Performance/HashPerformanceTests.cs
@@ -1,0 +1,219 @@
+﻿using Athena.Cache.Core.Configuration;
+using Athena.Cache.Core.Implementations;
+using FluentAssertions;
+using System.Diagnostics;
+using System.IO.Hashing;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Athena.Cache.Tests.Performance;
+
+/// <summary>
+/// SHA256 vs XxHash64 성능 비교 테스트
+/// </summary>
+public class HashPerformanceTests
+{
+    [Fact]
+    public async Task XxHash64_vs_SHA256_HashingPerformance()
+    {
+        // Arrange
+        const int iterations = 10000;
+        var testInputs = new[]
+        {
+            "simple string",
+            """{"userId":123,"category":"electronics","sortBy":"price","page":1,"pageSize":20,"includeTax":true}""",
+            "Very long string with lots of content that should test the performance of hash functions with larger inputs to see how they scale with data size",
+            new string('A', 1000), // 1KB 문자열
+            new string('B', 10000)  // 10KB 문자열
+        };
+
+        foreach (var input in testInputs)
+        {
+            Console.WriteLine($"\n=== 입력 크기: {input.Length} bytes ===");
+            
+            // XxHash64 성능 측정
+            var stopwatch = Stopwatch.StartNew();
+            ulong xxHashResult = 0;
+            
+            for (int i = 0; i < iterations; i++)
+            {
+                var inputBytes = Encoding.UTF8.GetBytes(input);
+                xxHashResult = XxHash64.HashToUInt64(inputBytes);
+            }
+            
+            var xxHashTime = stopwatch.ElapsedMilliseconds;
+            
+            // SHA256 성능 측정
+            stopwatch.Restart();
+            byte[] sha256Result = null!;
+            
+            for (int i = 0; i < iterations; i++)
+            {
+                var inputBytes = Encoding.UTF8.GetBytes(input);
+                sha256Result = SHA256.HashData(inputBytes);
+            }
+            
+            var sha256Time = stopwatch.ElapsedMilliseconds;
+
+            // 결과 출력
+            Console.WriteLine($"XxHash64: {xxHashTime}ms (결과: {xxHashResult})");
+            Console.WriteLine($"SHA256: {sha256Time}ms (결과: {Convert.ToHexString(sha256Result)[..16]}...)");
+            Console.WriteLine($"성능 향상: {(double)sha256Time / xxHashTime:F1}x 빠름");
+            
+            // 성능 검증 - 전체적으로 XxHash64가 더 빠르거나 비슷해야 함 (작은 데이터에서는 초기화 오버헤드로 인해 차이가 적을 수 있음)
+            if (input.Length > 100) // 큰 데이터에서만 엄격한 성능 검증
+            {
+                xxHashTime.Should().BeLessThan(sha256Time, "XxHash64가 SHA256보다 빨라야 함 (큰 데이터)");
+            }
+            else
+            {
+                xxHashTime.Should().BeLessThanOrEqualTo(sha256Time * 2, "XxHash64가 SHA256보다 2배 이상 느리지 않아야 함 (작은 데이터)");
+            }
+        }
+    }
+
+    [Fact]
+    public async Task CacheKeyGenerator_Performance_Comparison()
+    {
+        // Arrange
+        const int iterations = 5000;
+        var options = new AthenaCacheOptions
+        {
+            Namespace = "PerfTest",
+            VersionKey = "v2.0"
+        };
+        
+        // XxHash64 기반 키 생성기 (새 구현)
+        var newKeyGenerator = new DefaultCacheKeyGenerator(options);
+        
+        var testParameters = new Dictionary<string, object?>[]
+        {
+            new() { { "userId", 123 }, { "category", "electronics" } },
+            new() { { "userId", 456 }, { "category", "books" }, { "sortBy", "price" }, { "page", 1 } },
+            new() { { "search", "laptop computer" }, { "minPrice", 500.0 }, { "maxPrice", 2000.0 }, { "inStock", true } },
+            new() { { "filters", new[] { "brand", "rating", "availability" } }, { "limit", 50 } }
+        };
+
+        var totalNewTime = 0L;
+        var totalCacheHits = 0;
+
+        foreach (var parameters in testParameters)
+        {
+            Console.WriteLine($"\n=== 파라미터 수: {parameters.Count} ===");
+            
+            // 새 키 생성기 성능 측정 (키 캐싱 포함)
+            var stopwatch = Stopwatch.StartNew();
+            var generatedKeys = new HashSet<string>();
+            
+            for (int i = 0; i < iterations; i++)
+            {
+                var key = newKeyGenerator.GenerateKey("TestController", "TestAction", parameters);
+                generatedKeys.Add(key);
+            }
+            
+            var newTime = stopwatch.ElapsedMilliseconds;
+            totalNewTime += newTime;
+            
+            // 키 캐싱이 동작하는지 확인 (같은 파라미터로 여러 번 호출해도 같은 키)
+            generatedKeys.Should().HaveCount(1, "같은 파라미터는 같은 키를 생성해야 함");
+            
+            // 결과 출력
+            Console.WriteLine($"XxHash64 + 캐싱: {newTime}ms");
+            Console.WriteLine($"평균 시간/키: {(double)newTime / iterations:F4}ms");
+            Console.WriteLine($"생성된 키: {generatedKeys.First()}");
+        }
+
+        // 전체 성능 목표 검증
+        var avgTimePerKey = (double)totalNewTime / (iterations * testParameters.Length);
+        Console.WriteLine($"\n=== 전체 성능 결과 ===");
+        Console.WriteLine($"총 시간: {totalNewTime}ms");
+        Console.WriteLine($"평균 키 생성 시간: {avgTimePerKey:F4}ms");
+        
+        // 성능 목표: 평균 0.1ms 미만 (현실적인 목표, 키 캐싱 효과로 실제로는 더 빠름)
+        avgTimePerKey.Should().BeLessThan(0.1, "키 생성이 평균 0.1ms 미만이어야 함");
+    }
+
+    [Fact]
+    public async Task KeyCaching_Effectiveness_Test()
+    {
+        // Arrange
+        var options = new AthenaCacheOptions { Namespace = "CacheTest" };
+        var keyGenerator = new DefaultCacheKeyGenerator(options);
+        
+        var parameters = new Dictionary<string, object?>
+        {
+            { "userId", 123 },
+            { "category", "electronics" },
+            { "page", 1 }
+        };
+
+        // 첫 번째 호출 (캐시 미스)
+        var stopwatch = Stopwatch.StartNew();
+        var key1 = keyGenerator.GenerateKey("TestController", "TestAction", parameters);
+        var firstCallTime = stopwatch.ElapsedTicks;
+
+        // 두 번째 호출 (캐시 히트)
+        stopwatch.Restart();
+        var key2 = keyGenerator.GenerateKey("TestController", "TestAction", parameters);
+        var secondCallTime = stopwatch.ElapsedTicks;
+
+        // 결과 검증
+        key1.Should().Be(key2, "같은 파라미터는 같은 키를 반환해야 함");
+        secondCallTime.Should().BeLessThan(firstCallTime, "캐시된 키 조회가 더 빨라야 함");
+        
+        Console.WriteLine($"첫 번째 호출: {firstCallTime} ticks");
+        Console.WriteLine($"두 번째 호출: {secondCallTime} ticks");
+        Console.WriteLine($"캐시 효과: {(double)firstCallTime / secondCallTime:F1}x 빠름");
+        Console.WriteLine($"생성된 키: {key1}");
+    }
+
+    [Fact]
+    public async Task Base36_Encoding_Performance()
+    {
+        // Arrange
+        const int iterations = 10000;
+        var testValues = new ulong[]
+        {
+            0UL,
+            123456789UL,
+            ulong.MaxValue / 2,
+            ulong.MaxValue
+        };
+
+        foreach (var value in testValues)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            string result = null!;
+            
+            for (int i = 0; i < iterations; i++)
+            {
+                result = ConvertToBase36(value);
+            }
+            
+            var elapsed = stopwatch.ElapsedMilliseconds;
+            
+            Console.WriteLine($"값: {value} → Base36: {result} ({elapsed}ms, {iterations} 회)");
+            
+            // 성능 목표: 50ms 미만 (현실적인 목표)
+            elapsed.Should().BeLessThan(50, "Base36 인코딩이 빨라야 함");
+        }
+    }
+
+    /// <summary>
+    /// UInt64를 Base36 문자열로 변환 (테스트용 복사)
+    /// </summary>
+    private static string ConvertToBase36(ulong value)
+    {
+        const string chars = "0123456789abcdefghijklmnopqrstuvwxyz";
+        if (value == 0) return "0";
+
+        var result = new StringBuilder();
+        while (value > 0)
+        {
+            result.Insert(0, chars[(int)(value % 36)]);
+            value /= 36;
+        }
+        
+        return result.ToString();
+    }
+}

--- a/Athena.Cache.Tests/Performance/MessagePackPerformanceTests.cs
+++ b/Athena.Cache.Tests/Performance/MessagePackPerformanceTests.cs
@@ -1,0 +1,246 @@
+﻿using Athena.Cache.Core.Configuration;
+using Athena.Cache.Core.Implementations;
+using Athena.Cache.Core.Middleware;
+using FluentAssertions;
+using MessagePack;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace Athena.Cache.Tests.Performance;
+
+/// <summary>
+/// MessagePack vs JSON 성능 비교 테스트
+/// </summary>
+public class MessagePackPerformanceTests
+{
+    [MessagePackObject]
+    public class TestData
+    {
+        [Key(0)]
+        public int Id { get; set; }
+        
+        [Key(1)]
+        public string Name { get; set; } = string.Empty;
+        
+        [Key(2)]
+        public DateTime CreatedAt { get; set; }
+        
+        [Key(3)]
+        public List<string> Tags { get; set; } = new();
+        
+        [Key(4)]
+        public Dictionary<string, object> Properties { get; set; } = new();
+    }
+
+    [Fact]
+    public async Task MessagePack_vs_JSON_SerializationPerformance()
+    {
+        // Arrange
+        const int iterations = 1000;
+        var testData = new TestData
+        {
+            Id = 12345,
+            Name = "Performance Test Data",
+            CreatedAt = DateTime.UtcNow,
+            Tags = new List<string> { "performance", "test", "cache", "serialization" },
+            Properties = new Dictionary<string, object>
+            {
+                { "category", "electronics" },
+                { "price", 299.99m },
+                { "inStock", true },
+                { "ratings", new[] { 4.5, 4.8, 4.2, 4.9 } }
+            }
+        };
+
+        // MessagePack 직렬화 성능 측정
+        var stopwatch = Stopwatch.StartNew();
+        byte[] messagePackData = null!;
+        
+        for (int i = 0; i < iterations; i++)
+        {
+            messagePackData = MessagePackSerializer.Serialize(testData);
+        }
+        
+        var messagePackSerializeTime = stopwatch.ElapsedMilliseconds;
+        
+        // MessagePack 역직렬화 성능 측정
+        stopwatch.Restart();
+        TestData messagePackResult = null!;
+        
+        for (int i = 0; i < iterations; i++)
+        {
+            messagePackResult = MessagePackSerializer.Deserialize<TestData>(messagePackData);
+        }
+        
+        var messagePackDeserializeTime = stopwatch.ElapsedMilliseconds;
+
+        // JSON 직렬화 성능 측정
+        stopwatch.Restart();
+        string jsonData = null!;
+        
+        for (int i = 0; i < iterations; i++)
+        {
+            jsonData = JsonSerializer.Serialize(testData);
+        }
+        
+        var jsonSerializeTime = stopwatch.ElapsedMilliseconds;
+        
+        // JSON 역직렬화 성능 측정
+        stopwatch.Restart();
+        TestData jsonResult = null!;
+        
+        for (int i = 0; i < iterations; i++)
+        {
+            jsonResult = JsonSerializer.Deserialize<TestData>(jsonData)!;
+        }
+        
+        var jsonDeserializeTime = stopwatch.ElapsedMilliseconds;
+
+        // 결과 출력
+        var messagePackSize = messagePackData.Length;
+        var jsonSize = System.Text.Encoding.UTF8.GetByteCount(jsonData);
+        
+        Console.WriteLine($"=== 성능 비교 결과 ({iterations}회 반복) ===");
+        Console.WriteLine($"MessagePack - 직렬화: {messagePackSerializeTime}ms, 역직렬화: {messagePackDeserializeTime}ms, 크기: {messagePackSize} bytes");
+        Console.WriteLine($"JSON - 직렬화: {jsonSerializeTime}ms, 역직렬화: {jsonDeserializeTime}ms, 크기: {jsonSize} bytes");
+        Console.WriteLine($"성능 향상 - 직렬화: {(double)jsonSerializeTime / messagePackSerializeTime:F1}x, 역직렬화: {(double)jsonDeserializeTime / messagePackDeserializeTime:F1}x");
+        Console.WriteLine($"크기 절약: {(1 - (double)messagePackSize / jsonSize):P1}");
+
+        // 성능 검증
+        messagePackSerializeTime.Should().BeLessThan(jsonSerializeTime, "MessagePack 직렬화가 더 빨라야 함");
+        messagePackDeserializeTime.Should().BeLessThan(jsonDeserializeTime, "MessagePack 역직렬화가 더 빨라야 함");
+        messagePackSize.Should().BeLessThan(jsonSize, "MessagePack이 더 작은 크기를 가져야 함");
+        
+        // 데이터 정확성 검증
+        messagePackResult.Id.Should().Be(testData.Id);
+        messagePackResult.Name.Should().Be(testData.Name);
+        messagePackResult.Tags.Should().BeEquivalentTo(testData.Tags);
+    }
+
+    [Fact]
+    public async Task CacheProvider_MessagePack_vs_JSON_Performance()
+    {
+        // Arrange
+        const int operations = 500;
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var mockLogger = new Mock<ILogger<MemoryCacheProvider>>();
+        var options = new AthenaCacheOptions { DefaultExpirationMinutes = 30 };
+        var cacheProvider = new MemoryCacheProvider(memoryCache, options, mockLogger.Object);
+
+        var testData = Enumerable.Range(1, operations)
+            .Select(i => new TestData
+            {
+                Id = i,
+                Name = $"Test Item {i}",
+                CreatedAt = DateTime.UtcNow.AddMinutes(-i),
+                Tags = new List<string> { $"tag{i}", "performance", "test" },
+                Properties = new Dictionary<string, object>
+                {
+                    { "index", i },
+                    { "isEven", i % 2 == 0 },
+                    { "value", i * 1.5 }
+                }
+            })
+            .ToDictionary(x => $"test_key_{x.Id}", x => x);
+
+        // 캐시 저장 성능 측정
+        var stopwatch = Stopwatch.StartNew();
+        
+        foreach (var kvp in testData)
+        {
+            await cacheProvider.SetAsync(kvp.Key, kvp.Value);
+        }
+        
+        var setTime = stopwatch.ElapsedMilliseconds;
+        
+        // 캐시 조회 성능 측정
+        stopwatch.Restart();
+        var retrievedData = new List<TestData>();
+        
+        foreach (var key in testData.Keys)
+        {
+            var cached = await cacheProvider.GetAsync<TestData>(key);
+            if (cached != null)
+            {
+                retrievedData.Add(cached);
+            }
+        }
+        
+        var getTime = stopwatch.ElapsedMilliseconds;
+
+        // 결과 출력 및 검증
+        Console.WriteLine($"=== 캐시 성능 테스트 결과 ({operations}개 항목) ===");
+        Console.WriteLine($"저장 시간: {setTime}ms (평균 {(double)setTime / operations:F2}ms/item)");
+        Console.WriteLine($"조회 시간: {getTime}ms (평균 {(double)getTime / operations:F2}ms/item)");
+        
+        // 성능 목표 검증
+        setTime.Should().BeLessThan(2000, "저장 작업이 2초 미만이어야 함");
+        getTime.Should().BeLessThan(1000, "조회 작업이 1초 미만이어야 함");
+        retrievedData.Should().HaveCount(operations, "모든 데이터가 정상적으로 캐시되고 조회되어야 함");
+        
+        // 데이터 무결성 검증
+        var firstItem = retrievedData.First();
+        firstItem.Should().NotBeNull();
+        firstItem.Properties.Should().ContainKey("index");
+    }
+
+    [Fact]
+    public async Task CachedResponse_MessagePack_Serialization()
+    {
+        // Arrange
+        const int iterations = 100;
+        var cachedResponse = new CachedResponse
+        {
+            StatusCode = 200,
+            ContentType = "application/json",
+            Content = """{"message": "Hello World", "timestamp": "2024-01-01T00:00:00Z", "data": [1,2,3,4,5]}""",
+            Headers = new Dictionary<string, string>
+            {
+                { "Cache-Control", "public, max-age=3600" },
+                { "Content-Encoding", "gzip" },
+                { "X-Custom-Header", "custom-value" }
+            },
+            CachedAt = DateTime.UtcNow
+        };
+
+        // MessagePack 직렬화 성능 측정
+        var stopwatch = Stopwatch.StartNew();
+        byte[] serializedData = null!;
+        
+        for (int i = 0; i < iterations; i++)
+        {
+            serializedData = MessagePackSerializer.Serialize(cachedResponse);
+        }
+        
+        var serializeTime = stopwatch.ElapsedMilliseconds;
+        
+        // MessagePack 역직렬화 성능 측정
+        stopwatch.Restart();
+        CachedResponse deserializedResponse = null!;
+        
+        for (int i = 0; i < iterations; i++)
+        {
+            deserializedResponse = MessagePackSerializer.Deserialize<CachedResponse>(serializedData);
+        }
+        
+        var deserializeTime = stopwatch.ElapsedMilliseconds;
+
+        // 결과 출력 및 검증
+        Console.WriteLine($"=== CachedResponse 직렬화 성능 ({iterations}회) ===");
+        Console.WriteLine($"직렬화: {serializeTime}ms, 역직렬화: {deserializeTime}ms, 크기: {serializedData.Length} bytes");
+        
+        // 성능 목표
+        serializeTime.Should().BeLessThan(100, "CachedResponse 직렬화가 빨라야 함");
+        deserializeTime.Should().BeLessThan(100, "CachedResponse 역직렬화가 빨라야 함");
+        
+        // 데이터 무결성 검증
+        deserializedResponse.StatusCode.Should().Be(cachedResponse.StatusCode);
+        deserializedResponse.ContentType.Should().Be(cachedResponse.ContentType);
+        deserializedResponse.Content.Should().Be(cachedResponse.Content);
+        deserializedResponse.Headers.Should().BeEquivalentTo(cachedResponse.Headers);
+        deserializedResponse.CachedAt.Should().BeCloseTo(cachedResponse.CachedAt, TimeSpan.FromSeconds(1));
+    }
+}

--- a/Athena.Cache.Tests/Performance/MessagePackPerformanceTests.cs
+++ b/Athena.Cache.Tests/Performance/MessagePackPerformanceTests.cs
@@ -29,7 +29,7 @@ public class MessagePackPerformanceTests
         public DateTime CreatedAt { get; set; }
         
         [Key(3)]
-        public List<string> Tags { get; set; } = new();
+        public List<string> Tags { get; set; } = [];
         
         [Key(4)]
         public Dictionary<string, object> Properties { get; set; } = new();
@@ -45,7 +45,7 @@ public class MessagePackPerformanceTests
             Id = 12345,
             Name = "Performance Test Data",
             CreatedAt = DateTime.UtcNow,
-            Tags = new List<string> { "performance", "test", "cache", "serialization" },
+            Tags = ["performance", "test", "cache", "serialization"],
             Properties = new Dictionary<string, object>
             {
                 { "category", "electronics" },
@@ -136,7 +136,7 @@ public class MessagePackPerformanceTests
                 Id = i,
                 Name = $"Test Item {i}",
                 CreatedAt = DateTime.UtcNow.AddMinutes(-i),
-                Tags = new List<string> { $"tag{i}", "performance", "test" },
+                Tags = [$"tag{i}", "performance", "test"],
                 Properties = new Dictionary<string, object>
                 {
                     { "index", i },

--- a/Athena.Cache.Tests/Performance/Phase4OptimizationTests.cs
+++ b/Athena.Cache.Tests/Performance/Phase4OptimizationTests.cs
@@ -190,19 +190,12 @@ public class Phase4OptimizationTests
 /// <summary>
 /// 테스트용 서비스 프로바이더
 /// </summary>
-internal class TestServiceProvider : IServiceProvider
+internal class TestServiceProvider(ObjectPoolProvider poolProvider) : IServiceProvider
 {
-    private readonly ObjectPoolProvider _poolProvider;
-    
-    public TestServiceProvider(ObjectPoolProvider poolProvider)
-    {
-        _poolProvider = poolProvider;
-    }
-    
     public object? GetService(Type serviceType)
     {
         if (serviceType == typeof(ObjectPoolProvider))
-            return _poolProvider;
+            return poolProvider;
             
         return null;
     }

--- a/Athena.Cache.Tests/Performance/Phase4OptimizationTests.cs
+++ b/Athena.Cache.Tests/Performance/Phase4OptimizationTests.cs
@@ -1,0 +1,209 @@
+using Athena.Cache.Core.Configuration;
+using Athena.Cache.Core.Diagnostics;
+using Athena.Cache.Core.Implementations;
+using Athena.Cache.Core.Middleware;
+using Athena.Cache.Core.ObjectPools;
+using FluentAssertions;
+using Microsoft.Extensions.ObjectPool;
+using System.Diagnostics;
+
+namespace Athena.Cache.Tests.Performance;
+
+/// <summary>
+/// Phase 4 고급 최적화 성능 테스트
+/// </summary>
+public class Phase4OptimizationTests
+{
+    [Fact]
+    public async Task ObjectPooling_Performance_Test()
+    {
+        // Arrange
+        const int iterations = 10000;
+        var poolProvider = new DefaultObjectPoolProvider();
+        var pool = new CachedResponsePool(new TestServiceProvider(poolProvider));
+
+        // 일반 생성 vs Object Pool 성능 비교
+        var stopwatch = Stopwatch.StartNew();
+        
+        // 일반 객체 생성
+        for (int i = 0; i < iterations; i++)
+        {
+            var response = new CachedResponse();
+            response.Initialize(200, "application/json", "test content", new(), DateTime.UtcNow.AddMinutes(10));
+        }
+        
+        var regularTime = stopwatch.ElapsedMilliseconds;
+        
+        // Object Pool 사용
+        stopwatch.Restart();
+        var pooledObjects = new List<CachedResponse>();
+        
+        for (int i = 0; i < iterations; i++)
+        {
+            var response = pool.Get();
+            response.Initialize(200, "application/json", "test content", new(), DateTime.UtcNow.AddMinutes(10));
+            pooledObjects.Add(response);
+        }
+        
+        // 풀에 반환
+        foreach (var obj in pooledObjects)
+        {
+            pool.Return(obj);
+        }
+        
+        var poolTime = stopwatch.ElapsedMilliseconds;
+        
+        Console.WriteLine($"일반 생성: {regularTime}ms");
+        Console.WriteLine($"Object Pool: {poolTime}ms");
+        Console.WriteLine($"성능 향상: {(double)regularTime / poolTime:F1}x");
+        
+        // Object Pool이 더 빠르거나 비슷해야 함
+        poolTime.Should().BeLessThanOrEqualTo((long)(regularTime * 1.5), "Object Pool이 크게 느리지 않아야 함");
+    }
+
+    [Fact]
+    public async Task ValueTask_vs_Task_Performance()
+    {
+        // Arrange
+        const int iterations = 50000;
+        var options = new AthenaCacheOptions { Namespace = "PerfTest" };
+        var keyGenerator = new DefaultCacheKeyGenerator(options);
+        
+        var parameters = new Dictionary<string, object?>
+        {
+            { "userId", 123 },
+            { "category", "test" }
+        };
+
+        // Task 버전 (동기 메서드를 Task.FromResult로 래핑한다고 가정)
+        var stopwatch = Stopwatch.StartNew();
+        
+        for (int i = 0; i < iterations; i++)
+        {
+            var key = keyGenerator.GenerateKey("TestController", "TestAction", parameters);
+        }
+        
+        var syncTime = stopwatch.ElapsedMilliseconds;
+        
+        // ValueTask 버전
+        stopwatch.Restart();
+        
+        for (int i = 0; i < iterations; i++)
+        {
+            var key = await keyGenerator.GenerateKeyAsync("TestController", "TestAction", parameters);
+        }
+        
+        var valueTaskTime = stopwatch.ElapsedMilliseconds;
+        
+        Console.WriteLine($"동기 버전: {syncTime}ms");
+        Console.WriteLine($"ValueTask 버전: {valueTaskTime}ms");
+        Console.WriteLine($"비교: {(double)syncTime / valueTaskTime:F1}x");
+        
+        // ValueTask 버전이 더 빠르거나 비슷해야 함
+        valueTaskTime.Should().BeLessThanOrEqualTo((long)(syncTime * 1.2), "ValueTask가 크게 느리지 않아야 함");
+    }
+
+    [Fact]
+    public async Task ConcurrentDictionary_Optimization_Test()
+    {
+        // Arrange
+        const int iterations = 100000;
+        const int concurrency = 10;
+        var options = new AthenaCacheOptions { Namespace = "ConcurrencyTest" };
+        
+        // 최적화된 키 생성기
+        var optimizedGenerator = new DefaultCacheKeyGenerator(options);
+        
+        // 병렬 처리 테스트
+        var stopwatch = Stopwatch.StartNew();
+        var tasks = new List<Task>();
+        
+        for (int t = 0; t < concurrency; t++)
+        {
+            var taskIndex = t;
+            tasks.Add(Task.Run(async () =>
+            {
+                for (int i = 0; i < iterations / concurrency; i++)
+                {
+                    var parameters = new Dictionary<string, object?>
+                    {
+                        { "threadId", taskIndex },
+                        { "iteration", i },
+                        { "data", $"test-data-{i}" }
+                    };
+                    
+                    var key = await optimizedGenerator.GenerateKeyAsync("TestController", "TestAction", parameters);
+                }
+            }));
+        }
+        
+        await Task.WhenAll(tasks);
+        var elapsedTime = stopwatch.ElapsedMilliseconds;
+        
+        Console.WriteLine($"병렬 키 생성 ({concurrency} 스레드, {iterations} 회): {elapsedTime}ms");
+        Console.WriteLine($"평균 키 생성 시간: {(double)elapsedTime / iterations:F4}ms");
+        
+        // 성능 목표: 평균 0.01ms 미만
+        var avgTime = (double)elapsedTime / iterations;
+        avgTime.Should().BeLessThan(0.01, "병렬 환경에서도 키 생성이 빨라야 함");
+    }
+
+    [Fact]
+    public void PerformanceMonitor_Overhead_Test()
+    {
+        // Arrange
+        const int iterations = 100000;
+        using var monitor = new CachePerformanceMonitor();
+        
+        // 모니터링 없이 실행
+        var stopwatch = Stopwatch.StartNew();
+        
+        for (int i = 0; i < iterations; i++)
+        {
+            // 간단한 작업 시뮬레이션
+            Thread.SpinWait(100);
+        }
+        
+        var withoutMonitoringTime = stopwatch.ElapsedMilliseconds;
+        
+        // 모니터링과 함께 실행
+        stopwatch.Restart();
+        
+        for (int i = 0; i < iterations; i++)
+        {
+            using var measurement = monitor.StartMeasurement("test_operation");
+            Thread.SpinWait(100);
+        }
+        
+        var withMonitoringTime = stopwatch.ElapsedMilliseconds;
+        
+        Console.WriteLine($"모니터링 없음: {withoutMonitoringTime}ms");
+        Console.WriteLine($"모니터링 포함: {withMonitoringTime}ms");
+        Console.WriteLine($"오버헤드: {((double)withMonitoringTime / withoutMonitoringTime - 1) * 100:F1}%");
+        
+        // 모니터링 오버헤드가 20% 미만이어야 함
+        var overhead = (double)withMonitoringTime / withoutMonitoringTime;
+        overhead.Should().BeLessThan(1.2, "성능 모니터링 오버헤드가 20% 미만이어야 함");
+    }
+}
+
+/// <summary>
+/// 테스트용 서비스 프로바이더
+/// </summary>
+internal class TestServiceProvider : IServiceProvider
+{
+    private readonly ObjectPoolProvider _poolProvider;
+    
+    public TestServiceProvider(ObjectPoolProvider poolProvider)
+    {
+        _poolProvider = poolProvider;
+    }
+    
+    public object? GetService(Type serviceType)
+    {
+        if (serviceType == typeof(ObjectPoolProvider))
+            return _poolProvider;
+            
+        return null;
+    }
+}

--- a/Athena.Cache.Tests/Performance/Phase5EnterpriseTests.cs
+++ b/Athena.Cache.Tests/Performance/Phase5EnterpriseTests.cs
@@ -1,0 +1,311 @@
+using Athena.Cache.Core.Abstractions;
+using Athena.Cache.Core.Configuration;
+using Athena.Cache.Core.Implementations;
+using Athena.Cache.Redis;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using StackExchange.Redis;
+using System.Diagnostics;
+
+namespace Athena.Cache.Tests.Performance;
+
+/// <summary>
+/// Phase 5 엔터프라이즈 기능 성능 테스트
+/// </summary>
+public class Phase5EnterpriseTests
+{
+    [Fact]
+    public async Task DistributedCacheInvalidation_Performance_Test()
+    {
+        // Arrange
+        const int iterations = 1000;
+        var mockRedis = new Mock<IConnectionMultiplexer>();
+        var mockDatabase = new Mock<IDatabase>();
+        var mockSubscriber = new Mock<ISubscriber>();
+        var mockLocalInvalidator = new Mock<ICacheInvalidator>();
+        var options = new AthenaCacheOptions { Namespace = "PerfTest" };
+        var logger = new Mock<ILogger<DistributedCacheInvalidator>>();
+
+        mockRedis.Setup(r => r.GetDatabase(It.IsAny<int>(), It.IsAny<object>())).Returns(mockDatabase.Object);
+        mockRedis.Setup(r => r.GetSubscriber(It.IsAny<object>())).Returns(mockSubscriber.Object);
+        mockRedis.Setup(r => r.IsConnected).Returns(true);
+
+        var distributedInvalidator = new DistributedCacheInvalidator(
+            mockRedis.Object, mockLocalInvalidator.Object, options, logger.Object);
+
+        // Act - 분산 무효화 성능 측정
+        var stopwatch = Stopwatch.StartNew();
+        
+        var tasks = new List<Task>();
+        for (int i = 0; i < iterations; i++)
+        {
+            tasks.Add(distributedInvalidator.BroadcastInvalidationAsync($"Table_{i % 10}"));
+        }
+        
+        await Task.WhenAll(tasks);
+        stopwatch.Stop();
+
+        // Assert
+        var avgTime = (double)stopwatch.ElapsedMilliseconds / iterations;
+        Console.WriteLine($"분산 무효화 평균 시간: {avgTime:F4}ms");
+        Console.WriteLine($"초당 무효화 처리량: {1000.0 / avgTime:F0} ops/sec");
+        
+        // 성능 목표: 평균 1ms 미만
+        avgTime.Should().BeLessThan(1.0, "분산 무효화가 1ms 미만이어야 함");
+        
+        // Redis 호출 확인
+        mockSubscriber.Verify(s => s.PublishAsync(It.IsAny<RedisChannel>(), It.IsAny<RedisValue>(), It.IsAny<CommandFlags>()), 
+            Times.Exactly(iterations));
+    }
+
+    [Fact]
+    public async Task IntelligentCacheManager_HotKeyDetection_Performance()
+    {
+        // Arrange
+        const int iterations = 10000;
+        const int uniqueKeys = 100;
+        var options = new AthenaCacheOptions { DefaultExpirationMinutes = 30 };
+        var logger = new Mock<ILogger<IntelligentCacheManager>>();
+        var cacheManager = new IntelligentCacheManager(options, logger.Object);
+
+        await cacheManager.StartHotKeyDetectionAsync();
+
+        // Act - Hot Key 감지를 위한 액세스 시뮬레이션
+        var stopwatch = Stopwatch.StartNew();
+        var random = new Random(42); // 결정적 시드
+
+        var tasks = new List<Task>();
+        for (int i = 0; i < iterations; i++)
+        {
+            var keyIndex = random.NextDouble() < 0.2 ? i % 10 : i % uniqueKeys; // 20%는 Hot Key (0-9)
+            var cacheKey = $"key_{keyIndex}";
+            var accessType = random.NextDouble() < 0.8 ? CacheAccessType.Hit : CacheAccessType.Miss;
+            
+            tasks.Add(cacheManager.RecordCacheAccessAsync(cacheKey, accessType));
+        }
+
+        await Task.WhenAll(tasks);
+        stopwatch.Stop();
+
+        // Hot Key 조회 성능 측정
+        var hotKeyStopwatch = Stopwatch.StartNew();
+        var hotKeys = await cacheManager.GetHotKeysAsync(10);
+        hotKeyStopwatch.Stop();
+
+        // Assert
+        var recordTime = (double)stopwatch.ElapsedMilliseconds / iterations;
+        Console.WriteLine($"캐시 액세스 기록 평균 시간: {recordTime:F4}ms");
+        Console.WriteLine($"Hot Key 조회 시간: {hotKeyStopwatch.ElapsedMilliseconds}ms");
+        Console.WriteLine($"감지된 Hot Key 수: {hotKeys.Count()}");
+
+        // 성능 목표
+        recordTime.Should().BeLessThan(0.01, "캐시 액세스 기록이 0.01ms 미만이어야 함");
+        hotKeyStopwatch.ElapsedMilliseconds.Should().BeLessThan(50, "Hot Key 조회가 50ms 미만이어야 함");
+        hotKeys.Should().NotBeEmpty("Hot Key가 감지되어야 함");
+
+        await cacheManager.StopHotKeyDetectionAsync();
+        cacheManager.Dispose();
+    }
+
+    [Fact]
+    public async Task AdaptiveTTL_Calculation_Performance()
+    {
+        // Arrange
+        const int iterations = 5000;
+        var options = new AthenaCacheOptions { DefaultExpirationMinutes = 30 };
+        var logger = new Mock<ILogger<IntelligentCacheManager>>();
+        var cacheManager = new IntelligentCacheManager(options, logger.Object);
+
+        // 다양한 액세스 패턴으로 키 준비
+        var testKeys = new[] { "hot_key", "warm_key", "cold_key", "new_key" };
+        
+        // Hot Key 시뮬레이션 (높은 액세스 빈도)
+        for (int i = 0; i < 100; i++)
+        {
+            await cacheManager.RecordCacheAccessAsync("hot_key", CacheAccessType.Hit);
+        }
+        
+        // Warm Key 시뮬레이션 (중간 액세스 빈도)
+        for (int i = 0; i < 20; i++)
+        {
+            await cacheManager.RecordCacheAccessAsync("warm_key", CacheAccessType.Hit);
+        }
+        
+        // Cold Key 시뮬레이션 (낮은 액세스 빈도)
+        for (int i = 0; i < 3; i++)
+        {
+            await cacheManager.RecordCacheAccessAsync("cold_key", CacheAccessType.Miss);
+        }
+
+        // Act - Adaptive TTL 계산 성능 측정
+        var stopwatch = Stopwatch.StartNew();
+        
+        var ttlTasks = new List<Task<TimeSpan>>();
+        for (int i = 0; i < iterations; i++)
+        {
+            var key = testKeys[i % testKeys.Length];
+            ttlTasks.Add(cacheManager.CalculateAdaptiveTtlAsync(key));
+        }
+        
+        var results = await Task.WhenAll(ttlTasks);
+        stopwatch.Stop();
+
+        // Assert
+        var avgTime = (double)stopwatch.ElapsedMilliseconds / iterations;
+        Console.WriteLine($"Adaptive TTL 계산 평균 시간: {avgTime:F4}ms");
+        
+        // TTL 결과 분석
+        var hotKeyTtl = results.Where((_, i) => testKeys[i % testKeys.Length] == "hot_key").First();
+        var coldKeyTtl = results.Where((_, i) => testKeys[i % testKeys.Length] == "cold_key").First();
+        var newKeyTtl = results.Where((_, i) => testKeys[i % testKeys.Length] == "new_key").First();
+        
+        Console.WriteLine($"Hot Key TTL: {hotKeyTtl.TotalMinutes:F1}분");
+        Console.WriteLine($"Cold Key TTL: {coldKeyTtl.TotalMinutes:F1}분");
+        Console.WriteLine($"New Key TTL: {newKeyTtl.TotalMinutes:F1}분");
+
+        // 성능 및 로직 검증
+        avgTime.Should().BeLessThan(0.1, "Adaptive TTL 계산이 0.1ms 미만이어야 함");
+        hotKeyTtl.Should().BeGreaterThan(newKeyTtl, "Hot Key가 더 긴 TTL을 가져야 함");
+        
+        cacheManager.Dispose();
+    }
+
+    [Fact]
+    public async Task CacheEviction_Policy_Performance()
+    {
+        // Arrange
+        const int keyCount = 1000;
+        const int evictionCount = 100;
+        var options = new AthenaCacheOptions { DefaultExpirationMinutes = 30 };
+        var logger = new Mock<ILogger<IntelligentCacheManager>>();
+        var cacheManager = new IntelligentCacheManager(options, logger.Object);
+
+        // 테스트 키들 생성 및 액세스 패턴 시뮬레이션
+        var random = new Random(42);
+        for (int i = 0; i < keyCount; i++)
+        {
+            var key = $"eviction_test_key_{i}";
+            var accessCount = random.Next(1, 50);
+            
+            for (int j = 0; j < accessCount; j++)
+            {
+                await cacheManager.RecordCacheAccessAsync(key, CacheAccessType.Hit);
+                await Task.Delay(1); // 시간 간격 시뮬레이션
+            }
+        }
+
+        // Act - 각 교체 정책별 성능 측정
+        var policies = new[] 
+        { 
+            CacheEvictionPolicy.LRU, 
+            CacheEvictionPolicy.LFU, 
+            CacheEvictionPolicy.Random,
+            CacheEvictionPolicy.FIFO
+        };
+
+        foreach (var policy in policies)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            await cacheManager.EvictCacheByPolicyAsync(policy, evictionCount);
+            stopwatch.Stop();
+
+            Console.WriteLine($"{policy} 정책 교체 시간: {stopwatch.ElapsedMilliseconds}ms");
+            
+            // 성능 목표: 100ms 미만
+            stopwatch.ElapsedMilliseconds.Should().BeLessThan(100, $"{policy} 정책이 100ms 미만이어야 함");
+        }
+
+        cacheManager.Dispose();
+    }
+
+    [Fact]
+    public async Task CacheWarming_Performance_Test()
+    {
+        // Arrange
+        const int warmingKeyCount = 500;
+        var options = new AthenaCacheOptions { DefaultExpirationMinutes = 30 };
+        var logger = new Mock<ILogger<IntelligentCacheManager>>();
+        var cacheManager = new IntelligentCacheManager(options, logger.Object);
+
+        var keysToWarm = Enumerable.Range(0, warmingKeyCount)
+            .Select(i => $"warm_key_{i}")
+            .ToList();
+
+        // Act - 캐시 워밍 성능 측정
+        var stopwatch = Stopwatch.StartNew();
+        await cacheManager.WarmCacheAsync(keysToWarm);
+        stopwatch.Stop();
+
+        // Assert
+        var avgTime = (double)stopwatch.ElapsedMilliseconds / warmingKeyCount;
+        Console.WriteLine($"캐시 워밍 총 시간: {stopwatch.ElapsedMilliseconds}ms");
+        Console.WriteLine($"키당 평균 워밍 시간: {avgTime:F4}ms");
+        Console.WriteLine($"초당 워밍 처리량: {warmingKeyCount * 1000.0 / stopwatch.ElapsedMilliseconds:F0} keys/sec");
+
+        // 성능 목표
+        stopwatch.ElapsedMilliseconds.Should().BeLessThan(5000, "캐시 워밍이 5초 미만이어야 함");
+        avgTime.Should().BeLessThan(10.0, "키당 워밍 시간이 10ms 미만이어야 함");
+
+        cacheManager.Dispose();
+    }
+
+    [Fact]
+    public async Task ConcurrentAccess_Performance_Test()
+    {
+        // Arrange
+        const int concurrentUsers = 50;
+        const int operationsPerUser = 100;
+        var options = new AthenaCacheOptions { DefaultExpirationMinutes = 30 };
+        var logger = new Mock<ILogger<IntelligentCacheManager>>();
+        var cacheManager = new IntelligentCacheManager(options, logger.Object);
+
+        await cacheManager.StartHotKeyDetectionAsync();
+
+        // Act - 동시 사용자 시뮬레이션
+        var stopwatch = Stopwatch.StartNew();
+        
+        var userTasks = Enumerable.Range(0, concurrentUsers).Select(async userId =>
+        {
+            for (int i = 0; i < operationsPerUser; i++)
+            {
+                var key = $"user_{userId}_key_{i % 10}"; // 각 사용자당 10개 키 순환
+                var accessType = i % 4 == 0 ? CacheAccessType.Miss : CacheAccessType.Hit;
+                
+                await cacheManager.RecordCacheAccessAsync(key, accessType);
+                
+                if (i % 20 == 0) // 가끔 TTL 계산
+                {
+                    await cacheManager.CalculateAdaptiveTtlAsync(key);
+                }
+                
+                if (i % 30 == 0) // 가끔 우선순위 계산
+                {
+                    await cacheManager.CalculateKeyPriorityAsync(key);
+                }
+            }
+        });
+
+        await Task.WhenAll(userTasks);
+        stopwatch.Stop();
+
+        // Hot Key 조회로 최종 검증
+        var hotKeys = await cacheManager.GetHotKeysAsync(20);
+
+        // Assert
+        var totalOps = concurrentUsers * operationsPerUser;
+        var opsPerSecond = totalOps * 1000.0 / stopwatch.ElapsedMilliseconds;
+        
+        Console.WriteLine($"동시 접근 테스트 완료 시간: {stopwatch.ElapsedMilliseconds}ms");
+        Console.WriteLine($"총 연산 수: {totalOps}");
+        Console.WriteLine($"초당 처리량: {opsPerSecond:F0} ops/sec");
+        Console.WriteLine($"검출된 Hot Key 수: {hotKeys.Count()}");
+
+        // 성능 목표
+        opsPerSecond.Should().BeGreaterThan(10000, "초당 10,000 연산 이상 처리해야 함");
+        hotKeys.Should().NotBeEmpty("동시 접근으로 Hot Key가 감지되어야 함");
+
+        await cacheManager.StopHotKeyDetectionAsync();
+        cacheManager.Dispose();
+    }
+}

--- a/Athena.Cache.sln
+++ b/Athena.Cache.sln
@@ -24,9 +24,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{03C24C82-D
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Athena.Cache.Analytics", "Athena.Cache.Analytics\Athena.Cache.Analytics.csproj", "{2E4605E8-EB66-4EAB-BADD-128E9BFFCBE6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Athena.Cache.Analytics", "Athena.Cache.Analytics\Athena.Cache.Analytics.csproj", "{2E4605E8-EB66-4EAB-BADD-128E9BFFCBE6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Athena.Cache.SourceGenerator", "Athena.Cache.SourceGenerator\Athena.Cache.SourceGenerator.csproj", "{4AA2CBAC-0D2E-4ECD-A529-9CA91CF05CC7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Athena.Cache.SourceGenerator", "Athena.Cache.SourceGenerator\Athena.Cache.SourceGenerator.csproj", "{4AA2CBAC-0D2E-4ECD-A529-9CA91CF05CC7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Athena.Cache.Monitoring", "Athena.Cache.Monitoring\Athena.Cache.Monitoring.csproj", "{FECF6192-D7A0-44F7-B760-C7FE2A49DACB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -58,6 +60,10 @@ Global
 		{4AA2CBAC-0D2E-4ECD-A529-9CA91CF05CC7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4AA2CBAC-0D2E-4ECD-A529-9CA91CF05CC7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4AA2CBAC-0D2E-4ECD-A529-9CA91CF05CC7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FECF6192-D7A0-44F7-B760-C7FE2A49DACB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FECF6192-D7A0-44F7-B760-C7FE2A49DACB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FECF6192-D7A0-44F7-B760-C7FE2A49DACB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FECF6192-D7A0-44F7-B760-C7FE2A49DACB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -69,6 +75,7 @@ Global
 		{8E78EE5B-EA90-479B-81BF-C24E68D4F6F4} = {CE8B05B8-5445-4B13-9EBB-486392B9E29C}
 		{2E4605E8-EB66-4EAB-BADD-128E9BFFCBE6} = {EA6E562B-CA6A-43AB-B329-4BE38DE45E74}
 		{4AA2CBAC-0D2E-4ECD-A529-9CA91CF05CC7} = {EA6E562B-CA6A-43AB-B329-4BE38DE45E74}
+		{FECF6192-D7A0-44F7-B760-C7FE2A49DACB} = {EA6E562B-CA6A-43AB-B329-4BE38DE45E74}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FA0453E9-B173-4B9B-A314-A78075A9F0BA}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,99 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.1.7] - 2024-08-02
+
+### Added
+- **Convention-based table name inference system**: Automatically infer table names from controller names (`UsersController` → `Users`)
+- **NoConventionInvalidationAttribute**: Disable convention-based inference for specific controllers/actions
+- **Multi-table mapping support**: Configure multiple tables for a single controller via `ControllerTableMappings`
+- **Custom table inferrer**: Support for custom multi-table inference functions
+- **Global exclusion settings**: Exclude specific controllers from convention inference via `ExcludedControllers`
+- **ReportsController sample**: Demonstrates manual cache control patterns with `NoConventionInvalidation`
+
+### Changed
+- **Reduced boilerplate**: No need to declare `CacheInvalidateOn` for basic table mappings
+- **Improved consistency**: Automatic consistency between R (Read) and CUD (Create/Update/Delete) operations
+- **Enhanced AthenaCacheActionFilter**: Intelligent merging of explicit declarations and convention-based inference
+- **Simplified controller code**: Basic table invalidation now handled automatically by convention
+
+### Fixed
+- **Cache invalidation mismatch**: Eliminated possibility of R/CUD invalidation rule inconsistencies
+- **Duplicate declarations**: Convention system prevents redundant `CacheInvalidateOn` attributes
+
+### Migration Guide
+
+#### Full Backward Compatibility
+- All existing v1.1.6 code continues to work without changes
+- Explicit `CacheInvalidateOn` declarations take precedence over convention inference
+- No breaking changes introduced
+
+#### Optional Optimizations
+```csharp
+// Before v1.1.7 (still works)
+[HttpGet]
+[AthenaCache]
+[CacheInvalidateOn("Users")]
+public async Task<IActionResult> GetUsers() { ... }
+
+[HttpPost]
+[CacheInvalidateOn("Users")]  
+public async Task<IActionResult> CreateUser() { ... }
+
+// After v1.1.7 (simplified)
+[HttpGet]
+[AthenaCache]
+public async Task<IActionResult> GetUsers() { ... }  // Users table auto-inferred
+
+[HttpPost]
+public async Task<IActionResult> CreateUser() { ... }  // Users table auto-invalidated
+```
+
+#### Configuration Options
+```csharp
+// Enable convention-based inference (default: true)
+builder.Services.AddAthenaCacheComplete(options => {
+    options.Convention.Enabled = true;
+    options.Convention.UsePluralizer = true;
+    
+    // Multi-table mapping
+    options.Convention.ControllerTableMappings["UsersController"] = ["Users", "UserProfiles"];
+    
+    // Global exclusions
+    options.Convention.ExcludedControllers.Add("ReportsController");
+});
+```
+
+#### Manual Cache Control
+```csharp
+[NoConventionInvalidation]  // Disable auto-inference
+public class ReportsController : ControllerBase
+{
+    [HttpGet]
+    [AthenaCache]  // Caching only, no auto-invalidation
+    
+    [HttpPost]
+    public async Task<IActionResult> Refresh()
+    {
+        // Manual cache invalidation
+        await _cacheInvalidator.InvalidateByPatternAsync("*Report*");
+    }
+}
+```
+
+### Priority System
+1. **Explicit CacheInvalidateOn** (highest priority)
+2. **NoConventionInvalidation check** (blocks convention)
+3. **Global ExcludedControllers** (blocks convention)  
+4. **Convention inference** (Settings mapping > Custom function > Default inference)
+
+### Performance Impact
+- No performance impact on existing functionality
+- Convention inference adds minimal overhead during application startup
+- Runtime performance unchanged

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Athena.Cache는 ASP.NET Core 애플리케이션을 위한 지능형 캐싱 라�
 - 🚀 **다중 백엔드 지원**: MemoryCache, Redis, Valkey 지원
 - 🎨 **선언적 캐싱**: `[AthenaCache]`, `[CacheInvalidateOn]` 어트리뷰트
 - ⚡ **고성능**: 대용량 트래픽 환경에 최적화, Primary Constructor 사용
+- 🧠 **제로 메모리 할당**: 5단계 최적화로 메모리 할당 90-98% 감소
+- 🔄 **자동 메모리 관리**: 실시간 GC 모니터링 및 자동 캐시 정리
 - 🔧 **쉬운 통합**: 단일 패키지 설치로 모든 기능 사용 가능
 - 🧪 **완전한 테스트**: 포괄적인 단위 및 통합 테스트
 
@@ -199,10 +201,34 @@ public class UserService
 
 ## 📊 성능
 
+### 🚀 기본 성능 지표
 - **높은 처리량**: Redis 기준 10,000+ requests/second
 - **낮은 지연시간**: 캐시 키 생성 1ms 미만
 - **메모리 효율성**: 최적화된 직렬화 및 압축
 - **확장 가능**: 다중 인스턴스 분산 무효화 지원
+
+### 🧠 제로 메모리 할당 최적화 결과
+| 최적화 영역 | 개선율 | 주요 기법 |
+|------------|-------|-----------|
+| **메모리 할당** | **90-98% 감소** | 컬렉션 풀링, Span/Memory, 캐싱 |
+| **GC 압박** | **~90% 감소** | 값 타입, 문자열 인터닝, 자동 정리 |
+| **문자열 처리** | **~98% 감소** | StringBuilder 풀링, 약한 참조 인터닝 |
+| **컬렉션 연산** | **~95% 감소** | LINQ 제거, 수동 루프, ArrayPool |
+| **박싱/언박싱** | **100% 제거** | 값 타입 구조체, 제네릭 통계 |
+
+### 📈 성능 테스트 데모
+```bash
+# 성능 비교 테스트 실행
+curl -X POST "http://localhost:5000/api/ZeroMemoryDemo/performance-comparison?iterations=10000"
+
+# 메모리 상태 확인
+curl "http://localhost:5000/api/ZeroMemoryDemo/memory-status"
+
+# 메모리 압박 시뮬레이션
+curl -X POST "http://localhost:5000/api/ZeroMemoryDemo/memory-pressure-test"
+```
+
+> 📋 **상세 가이드**: 제로 메모리 최적화 기법에 대한 자세한 설명은 [docs/ZeroMemoryOptimization.md](docs/ZeroMemoryOptimization.md)를 참조하세요.
 
 ## 🔧 설정 옵션
 

--- a/dashboards/grafana-athena-cache-dashboard.json
+++ b/dashboards/grafana-athena-cache-dashboard.json
@@ -1,0 +1,669 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Comprehensive monitoring dashboard for Athena.Cache performance and health metrics",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "prometheus",
+      "description": "Current cache hit ratio percentage",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.7
+              },
+              {
+                "color": "green",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "athena_cache_hit_ratio",
+          "interval": "",
+          "legendFormat": "Hit Ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Hit Ratio",
+      "type": "stat"
+    },
+    {
+      "datasource": "prometheus",
+      "description": "Total number of cached items",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "athena_cache_items_count",
+          "interval": "",
+          "legendFormat": "Items",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Items Count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "prometheus",
+      "description": "Memory usage by cache in MB",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 500
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
+            ]
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "athena_cache_memory_usage_bytes",
+          "interval": "",
+          "legendFormat": "Memory Usage",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Usage",
+      "type": "stat"
+    },
+    {
+      "datasource": "prometheus",
+      "description": "Number of detected hot keys",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 15
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "athena_cache_hot_keys_count",
+          "interval": "",
+          "legendFormat": "Hot Keys",
+          "refId": "A"
+        }
+      ],
+      "title": "Hot Keys Count",
+      "type": "stat"
+    },
+    {
+      "datasource": "prometheus",
+      "description": "Cache hits vs misses over time",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(athena_cache_hits_total[5m])",
+          "interval": "",
+          "legendFormat": "Hits/sec",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(athena_cache_misses_total[5m])",
+          "interval": "",
+          "legendFormat": "Misses/sec",
+          "refId": "B"
+        }
+      ],
+      "title": "Cache Hit/Miss Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "prometheus",
+      "description": "Cache operation duration percentiles",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(athena_cache_operation_duration_seconds_bucket[5m]))",
+          "interval": "",
+          "legendFormat": "50th percentile",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, rate(athena_cache_operation_duration_seconds_bucket[5m]))",
+          "interval": "",
+          "legendFormat": "95th percentile",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(athena_cache_operation_duration_seconds_bucket[5m]))",
+          "interval": "",
+          "legendFormat": "99th percentile",
+          "refId": "C"
+        }
+      ],
+      "title": "Operation Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "prometheus",
+      "description": "Cache invalidations by table",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },  
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(athena_cache_invalidations_total[5m])",
+          "interval": "",
+          "legendFormat": "{{table_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Invalidations by Table",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "prometheus",
+      "description": "Cache errors by type",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(athena_cache_errors_total[5m])",
+          "interval": "",
+          "legendFormat": "{{error_type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Errors",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [
+    "athena-cache",
+    "caching",
+    "performance",
+    "monitoring"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "prometheus",
+        "definition": "label_values(athena_cache_hits_total, cache_type)",
+        "description": "Cache type filter",
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": "Cache Type",
+        "multi": true,
+        "name": "cache_type",
+        "options": [],
+        "query": {
+          "query": "label_values(athena_cache_hits_total, cache_type)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Athena Cache - Performance Dashboard",
+  "uid": "athena-cache-dashboard",
+  "version": 1
+}

--- a/docs/ZeroMemoryOptimization.md
+++ b/docs/ZeroMemoryOptimization.md
@@ -1,0 +1,279 @@
+# Athena.Cache 제로 메모리 할당 최적화 가이드
+
+## 🚀 개요
+
+Athena.Cache는 **제로 메모리 할당**을 목표로 하는 고성능 캐싱 시스템입니다. 이 문서는 구현된 5단계 최적화 기법과 실제 사용 방법을 설명합니다.
+
+## 📊 성능 향상 결과
+
+| 최적화 영역 | 기존 대비 개선율 | 주요 기법 |
+|------------|----------------|-----------|
+| 메모리 할당 | **90-98% 감소** | 컬렉션 풀링, Span/Memory, 캐싱 |
+| GC 압박 | **~90% 감소** | 값 타입, 문자열 인터닝, 자동 정리 |
+| 문자열 처리 | **~98% 감소** | StringBuilder 풀링, 약한 참조 인터닝 |
+| 컬렉션 연산 | **~95% 감소** | LINQ 제거, 수동 루프, ArrayPool |
+| 박싱/언박싱 | **100% 제거** | 값 타입 구조체, 제네릭 통계 |
+
+## 💡 5단계 최적화 기법
+
+### Phase 1: 컬렉션 풀링 & 재사용
+```csharp
+// 기존 방식 (메모리 할당 발생)
+var recommendations = new List<OptimizationRecommendation>();
+var metrics = new Dictionary<string, object>();
+
+// 최적화된 방식 (풀에서 재사용)
+var recommendations = CollectionPools.RentOptimizationRecommendationList();
+var metrics = CollectionPools.RentStringObjectDictionary();
+try
+{
+    // 사용
+}
+finally
+{
+    CollectionPools.Return(recommendations);
+    CollectionPools.Return(metrics);
+}
+```
+
+### Phase 2: Span/Memory 전면 적용
+```csharp
+// 기존 방식 (문자열 할당)
+var bytes = Encoding.UTF8.GetBytes(input);
+var result = Encoding.UTF8.GetString(bytes);
+
+// 최적화된 방식 (Span 사용)
+var maxByteCount = Encoding.UTF8.GetMaxByteCount(input.Length);
+Span<byte> buffer = maxByteCount <= 1024 
+    ? stackalloc byte[maxByteCount]  // 스택 할당
+    : new byte[maxByteCount];        // 필요시만 힙 할당
+
+var actualByteCount = Encoding.UTF8.GetBytes(input.AsSpan(), buffer);
+var inputSpan = buffer.Slice(0, actualByteCount);
+```
+
+### Phase 3: LINQ 제거 & 저수준 최적화
+```csharp
+// 기존 방식 (LINQ - 중간 컬렉션 생성)
+var average = data.Where(x => x.IsValid).Select(x => x.Value).Average();
+var result = items.OrderByDescending(x => x.Priority).ToArray();
+
+// 최적화된 방식 (수동 루프)
+double sum = 0;
+int count = 0;
+for (int i = 0; i < data.Length; i++)
+{
+    if (data[i].IsValid)
+    {
+        sum += data[i].Value;
+        count++;
+    }
+}
+var average = count > 0 ? sum / count : 0.0;
+```
+
+### Phase 4: 캐싱 & 지연 초기화
+```csharp
+// 자주 사용되는 값들 캐싱
+public static string FormatPercentage(double ratio)
+{
+    // 캐시에서 먼저 확인
+    if (_percentageCache.TryGetValue(ratio, out var cached))
+        return cached;
+        
+    var result = MemoryUtils.FormatPercentage(ratio);
+    _percentageCache.TryAdd(ratio, result);
+    return result;
+}
+
+// 상수 문자열 인터닝
+public static readonly string CacheHit = LazyCache.InternString("HIT");
+public static readonly string CacheMiss = LazyCache.InternString("MISS");
+```
+
+### Phase 5: 고급 최적화
+```csharp
+// 값 타입 구조체로 박싱 제거
+[StructLayout(LayoutKind.Sequential, Pack = 8)]
+public readonly struct CacheMetrics
+{
+    public readonly long HitCount;
+    public readonly long MissCount;
+    public readonly double HitRatio;
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public string GetFormattedHitRatio() => LazyCache.FormatPercentage(HitRatio);
+}
+
+// StringBuilder 풀링
+var sb = HighPerformanceStringPool.RentStringBuilder(capacity);
+try
+{
+    // 문자열 구성
+    return sb.ToString();
+}
+finally
+{
+    HighPerformanceStringPool.ReturnStringBuilder(sb);
+}
+```
+
+## 🔧 주요 최적화 클래스들
+
+### 1. CollectionPools
+- **목적**: 컬렉션 재사용으로 할당 최소화
+- **사용법**: Rent → 사용 → Return 패턴
+```csharp
+var list = CollectionPools.RentOptimizationRecommendationList();
+// ... 사용
+CollectionPools.Return(list);
+```
+
+### 2. LazyCache
+- **목적**: 자주 사용되는 값들 캐싱
+- **특징**: 크기 제한, 자동 정리
+```csharp
+var percentage = LazyCache.FormatPercentage(0.85); // 캐싱됨
+var size = LazyCache.FormatByteSize(1024); // 캐싱됨
+```
+
+### 3. HighPerformanceStringPool
+- **목적**: 문자열 처리 최적화
+- **특징**: StringBuilder 풀링, 약한 참조 인터닝
+```csharp
+var sb = HighPerformanceStringPool.RentStringBuilder(256);
+var interned = HighPerformanceStringPool.InternWeakly("common_string");
+```
+
+### 4. MemoryPressureManager
+- **목적**: 자동 메모리 관리
+- **특징**: 실시간 모니터링, 단계별 정리
+```csharp
+// 자동으로 메모리 압박 감지 및 정리 수행
+var memoryStatus = memoryManager.GetMemoryStatus();
+memoryManager.ForceCleanup(MemoryPressureLevel.High);
+```
+
+### 5. ValueTypeOptimizations
+- **목적**: 박싱 제거, CPU 캐시 최적화
+- **특징**: 값 타입 구조체, 비트 연산
+```csharp
+var metrics = new CacheMetrics(hits, misses, errors, avgTime, memory);
+var average = ValueTypeStatistics.CalculateAverage<double>(values);
+```
+
+## 📈 메모리 사용량 모니터링
+
+### 캐시 통계 확인
+```csharp
+var cacheStats = LazyCache.GetCacheStats();
+Console.WriteLine($"Total cached items: {cacheStats.TotalCacheSize}");
+
+var poolStats = HighPerformanceStringPool.GetPoolStats();
+Console.WriteLine($"String pool memory: {poolStats.EstimatedMemoryUsage}");
+
+var memoryStatus = memoryManager.GetMemoryStatus();
+Console.WriteLine($"Memory pressure: {memoryStatus.PressureLevel}");
+```
+
+### 성능 메트릭 수집
+```csharp
+var metrics = new CacheMetrics(
+    hitCount: 1000,
+    missCount: 200,
+    errorCount: 5,
+    averageResponseTime: TimeSpan.FromMilliseconds(2.5),
+    memoryUsageBytes: 50 * 1024 * 1024
+);
+
+Console.WriteLine($"Hit Ratio: {metrics.GetFormattedHitRatio()}");
+Console.WriteLine($"Memory Usage: {metrics.GetFormattedMemoryUsage()}");
+Console.WriteLine($"Is Healthy: {metrics.IsHealthy()}");
+```
+
+## ⚙️ 설정 및 튜닝
+
+### 메모리 압박 임계값 조정
+```csharp
+// MemoryPressureManager에서 조정 가능한 값들
+private const long MemoryPressureThreshold = 512 * 1024 * 1024; // 512MB
+private const double GcFrequencyThreshold = 5.0; // 5초당 GC 횟수
+private const int MinCleanupIntervalMinutes = 5; // 최소 정리 간격
+```
+
+### 캐시 크기 제한 설정
+```csharp
+// LazyCache 설정
+private const int MaxCacheSize = 1000;
+
+// HighPerformanceStringPool 설정
+private const int MaxPoolSize = 100;
+private const int MaxInternPoolSize = 1000;
+```
+
+## 🎯 사용 권장사항
+
+### DO ✅
+- **항상 using/finally 블록**에서 풀 리소스 반환
+- **작은 데이터는 stackalloc** 사용 (1KB 이하)
+- **자주 사용되는 문자열은 인터닝** 적용
+- **값 타입 구조체** 우선 사용
+- **메모리 모니터링** 정기적 수행
+
+### DON'T ❌
+- 풀에서 빌린 객체를 **반환하지 않기**
+- **큰 객체를 stackalloc**으로 할당
+- **너무 긴 문자열 인터닝** (200자 이상)
+- **참조 타입에서 값 타입 박싱**
+- **메모리 누수 가능성 무시**
+
+## 🔍 디버깅 및 프로파일링
+
+### 메모리 누수 감지
+```csharp
+// 주기적으로 통계 확인
+var stats = LazyCache.GetCacheStats();
+if (stats.TotalCacheSize > ExpectedMaxSize)
+{
+    LazyCache.ClearCaches(); // 강제 정리
+}
+
+// GC 통계 모니터링
+var memoryStatus = memoryManager.GetMemoryStatus();
+logger.LogInformation("GC Stats: {GcStats}", memoryStatus.GcStatistics);
+```
+
+### 성능 프로파일링
+```csharp
+// Stopwatch로 성능 측정
+var stopwatch = Stopwatch.StartNew();
+// ... 캐시 작업
+stopwatch.Stop();
+logger.LogDebug("Cache operation took {Duration}ms", stopwatch.ElapsedMilliseconds);
+
+// 메모리 사용량 추적
+var beforeMemory = GC.GetTotalMemory(false);
+// ... 작업 수행
+var afterMemory = GC.GetTotalMemory(true);
+var allocated = afterMemory - beforeMemory;
+```
+
+## 📋 체크리스트
+
+프로덕션 배포 전 확인사항:
+
+- [ ] 모든 컬렉션 풀 리소스가 반환되는가?
+- [ ] 메모리 압박 매니저가 활성화되어 있는가?
+- [ ] 캐시 크기 제한이 적절히 설정되어 있는가?
+- [ ] 메모리 모니터링 로그가 활성화되어 있는가?
+- [ ] 성능 테스트에서 메모리 누수가 없는가?
+
+## 🔗 관련 링크
+
+- [System.Memory 성능 가이드](https://docs.microsoft.com/en-us/dotnet/standard/memory-and-spans/)
+- [.NET GC 최적화](https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/)
+- [고성능 .NET 코딩](https://docs.microsoft.com/en-us/dotnet/standard/performance/)
+
+---
+
+**Athena.Cache - 제로 메모리 할당으로 엔터프라이즈급 성능을 제공합니다** 🚀


### PR DESCRIPTION
### Added
- **Convention-based table name inference system**: Automatically infer table names from controller names (`UsersController` → `Users`)
- **NoConventionInvalidationAttribute**: Disable convention-based inference for specific controllers/actions
- **Multi-table mapping support**: Configure multiple tables for a single controller via `ControllerTableMappings`
- **Custom table inferrer**: Support for custom multi-table inference functions
- **Global exclusion settings**: Exclude specific controllers from convention inference via `ExcludedControllers`
- **ReportsController sample**: Demonstrates manual cache control patterns with `NoConventionInvalidation`

### Changed
- **Reduced boilerplate**: No need to declare `CacheInvalidateOn` for basic table mappings
- **Improved consistency**: Automatic consistency between R (Read) and CUD (Create/Update/Delete) operations
- **Enhanced AthenaCacheActionFilter**: Intelligent merging of explicit declarations and convention-based inference
- **Simplified controller code**: Basic table invalidation now handled automatically by convention

### Fixed
- **Cache invalidation mismatch**: Eliminated possibility of R/CUD invalidation rule inconsistencies
- **Duplicate declarations**: Convention system prevents redundant `CacheInvalidateOn` attributes